### PR TITLE
oauth, trusty policy fix,  IP acc. list, ext. loc.

### DIFF
--- a/aws/tf/modules/sra/databricks.tf
+++ b/aws/tf/modules/sra/databricks.tf
@@ -45,6 +45,7 @@ module "databricks_uc" {
   uc_iam_arn                      = aws_iam_role.unity_catalog_role.arn
   uc_iam_name                     = aws_iam_role.unity_catalog_role.name
   data_bucket                     = var.data_bucket
+  data_access                     = var.data_access
   storage_credential_role_name    = aws_iam_role.storage_credential_role.name
   storage_credential_role_arn     = aws_iam_role.storage_credential_role.arn
   depends_on = [
@@ -99,6 +100,20 @@ module "secret_management" {
     module.databricks_mws_workspace
     ]
 }
+
+// IP Access Lists
+# module "ip_access_list" {
+#     source = "./databricks/ip_access_list"
+#     providers = {
+#       databricks = databricks.created_workspace
+#     }
+
+#   ip_addresses = var.ip_addresses
+  
+#   depends_on = [
+#     module.databricks_mws_workspace
+#     ]
+# }
 
 // SAT Implementation - Optional
 # module "security_analysis_tool" {

--- a/aws/tf/modules/sra/databricks/ip_access_list/ip_access_list.tf
+++ b/aws/tf/modules/sra/databricks/ip_access_list/ip_access_list.tf
@@ -1,0 +1,16 @@
+// Terraform Documentation: https://registry.terraform.io/providers/databricks/databricks/latest/docs/resources/ip_access_list
+
+resource "databricks_workspace_conf" "this" {
+  custom_config = {
+    "enableIpAccessLists" = true
+  }
+}
+
+resource "databricks_ip_access_list" "allowed-list" {
+  label     = "allow_in"
+  list_type = "ALLOW"
+  ip_addresses = [
+    var.ip_addresses
+  ]
+  depends_on = [databricks_workspace_conf.this]
+}

--- a/aws/tf/modules/sra/databricks/ip_access_list/provider.tf
+++ b/aws/tf/modules/sra/databricks/ip_access_list/provider.tf
@@ -1,0 +1,7 @@
+terraform {
+  required_providers {
+    databricks = {
+      source = "databricks/databricks"
+    }
+  }
+}

--- a/aws/tf/modules/sra/databricks/ip_access_list/variables.tf
+++ b/aws/tf/modules/sra/databricks/ip_access_list/variables.tf
@@ -1,0 +1,3 @@
+variable "ip_addresses" {
+  type = list(string)
+}

--- a/aws/tf/modules/sra/databricks/unity_catalog/unity_catalog.tf
+++ b/aws/tf/modules/sra/databricks/unity_catalog/unity_catalog.tf
@@ -36,3 +36,22 @@ resource "databricks_storage_credential" "external" {
     databricks_metastore_assignment.default_metastore
   ]
 }
+
+// External Location
+resource "databricks_external_location" "data_example" {
+  name            = "external-location-example"
+  url             = "s3://${var.data_bucket}/"
+  credential_name = databricks_storage_credential.external.id
+  skip_validation = true
+  read_only       = true
+  comment         = "Managed by TF"
+}
+
+// External Location Grant
+resource "databricks_grants" "data_example" {
+  external_location = databricks_external_location.data_example.id
+  grant {
+    principal  = var.data_access
+    privileges = ["ALL_PRIVILEGES"]
+  }
+}

--- a/aws/tf/modules/sra/databricks/unity_catalog/variables.tf
+++ b/aws/tf/modules/sra/databricks/unity_catalog/variables.tf
@@ -22,6 +22,10 @@ variable "data_bucket" {
   type = string
 }
 
+variable "data_access" {
+  type = string
+}
+
 variable "storage_credential_role_name" {
   type = string
 }

--- a/aws/tf/modules/sra/network.tf
+++ b/aws/tf/modules/sra/network.tf
@@ -1,6 +1,6 @@
 module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"
-  version = "3.2.0"
+  version = "5.0.0"
 
   name = "${var.resource_prefix}-data-plane-VPC"
   cidr = var.vpc_cidr_range

--- a/aws/tf/modules/sra/provider.tf
+++ b/aws/tf/modules/sra/provider.tf
@@ -13,9 +13,9 @@ terraform {
 }
 
 provider "databricks" {
-  alias      = "created_workspace"
-  host       = module.databricks_mws_workspace.workspace_url
-  username   = var.databricks_account_username
-  password   = var.databricks_account_password
-  auth_type  = "basic"
+  alias    = "created_workspace"
+  host     = module.databricks_mws_workspace.workspace_url
+  account_id                = var.databricks_account_id
+  client_id                 = var.client_id
+  client_secret             = var.client_secret
 }

--- a/aws/tf/modules/sra/variables.tf
+++ b/aws/tf/modules/sra/variables.tf
@@ -3,12 +3,12 @@ variable "databricks_account_id" {
   sensitive = true
 }
 
-variable "databricks_account_password" {
+variable "client_id" {
   type = string
   sensitive = true
 }
 
-variable "databricks_account_username" {
+variable "client_secret" {
   type = string
   sensitive = true
 }
@@ -40,6 +40,10 @@ variable "ucname" {
 }
 
 variable "data_bucket" {
+  type = string
+}
+
+variable "data_access" {
   type = string
 }
 
@@ -78,4 +82,9 @@ variable "workspace_vpce_service" {
 variable "relay_vpce_service" {
   type = string
 }
+
+variable "ip_addresses" {
+  type = list(string)
+}
+
 

--- a/aws/tf/provider.tf
+++ b/aws/tf/provider.tf
@@ -2,7 +2,6 @@ terraform {
   required_providers {
     databricks = {
       source  = "databricks/databricks"
-      version = "1.8.0"
     }
     aws = {
       source  = "hashicorp/aws"
@@ -12,8 +11,6 @@ terraform {
 
 provider "aws" {
   region = var.region
-  access_key = var.aws_access_key
-  secret_key = var.aws_secret_key  
   default_tags {
     tags = {
     Owner = var.resource_owner
@@ -23,9 +20,9 @@ provider "aws" {
 }
 
 provider "databricks" {
-  alias      = "mws"
-  host       = "https://accounts.cloud.databricks.com"
-  username   = var.databricks_account_username
-  password   = var.databricks_account_password
-  auth_type  =  "basic"
+  alias                     = "mws"
+  host                      = "https://accounts.cloud.databricks.com"
+  account_id                = var.databricks_account_id
+  client_id                 = var.client_id
+  client_secret             = var.client_secret
 }

--- a/aws/tf/sra.tf
+++ b/aws/tf/sra.tf
@@ -1,18 +1,17 @@
 module "SRA" {
     source = "./modules/sra"
     providers = {
-      databricks.mws                = databricks.mws
-      aws                           = aws
+      databricks.mws            = databricks.mws
+      aws                       = aws
     }
   
    resource_prefix              = var.resource_prefix
    resource_owner               = var.resource_owner
    databricks_account_id        = var.databricks_account_id
-   databricks_account_username  = var.databricks_account_username
-   databricks_account_password  = var.databricks_account_password
+   client_id                    = var.client_id
+   client_secret                = var.client_secret
    aws_account_id               = var.aws_account_id
    region                       = var.region
-
    vpc_cidr_range               = "10.0.0.0/18"
 
    // Initial two private subnets are for workspace subnets, latter two are for VPC Interface Endpoints (Databricks (SCC + Relay), Kinesis, and STS)
@@ -27,8 +26,16 @@ module "SRA" {
    sg_ingress_protocol          = ["tcp", "udp"]
    sg_egress_protocol           = ["tcp", "udp"]
 
-   // Create an example storage credential and IAM role with read only access to this bucket 
-   data_bucket                  = "delta-lake-oss-emr-demo"
-   dbfsname                     = join("", [var.resource_prefix, "-", var.region, "-", "dbfsroot"]) 
+   //Corporate IP addresses for workspace access - disabled by default. Please uncomment IP access list module in databricks.tf to enable.
+   ip_addresses = ["1.1.1.1", "1.2.3.0/24", "1.2.5.0/24"]
+
+  // Unity Catalog & DBFS Root Bucket Names
+  dbfsname                      = join("", [var.resource_prefix, "-", var.region, "-", "dbfsroot"]) 
    ucname                       = join("", [var.resource_prefix, "-", var.region, "-", "uc"]) 
+
+   // Create an example AM role, storage credential, and external with read only access to a bucket for Unity Catalog. 
+   data_bucket                  = "<bucket_name>"
+
+   // Group or user that would like access to the external location created above.
+   data_access                  = "<user or group name>"
 }

--- a/aws/tf/variables.tf
+++ b/aws/tf/variables.tf
@@ -1,24 +1,14 @@
-variable "databricks_account_username" {
+variable "client_id" {
   type = string
   sensitive = true
 }
 
-variable "databricks_account_password" {
+variable "client_secret" {
   type = string
   sensitive = true
 }
 
 variable "databricks_account_id" {
-  type = string
-  sensitive = true
-}
-
-variable "aws_access_key" {
-  type = string
-  sensitive = true
-}
-
-variable "aws_secret_key" {
   type = string
   sensitive = true
 }


### PR DESCRIPTION
- Removed Databricks provider version
- Updated AWS VPC module provider version
- Changed default authentication to OAuth and removed basic authentication variables
- Removed AWS access key + secret variables
- Updated Unity Catalog & Storage Credential trust policy
- Added IP access list example resource
- Created external location + grant statement and relevant variables (data bucket + data access)