### PR TITLE
Updated Ports

### DIFF
--- a/aws/tf/modules/sra/privatelink.tf
+++ b/aws/tf/modules/sra/privatelink.tf
@@ -52,6 +52,14 @@ resource "aws_security_group" "privatelink" {
 
   ingress {
     description     = "Inbound rules"
+    from_port       = 2443
+    to_port         = 2443
+    protocol        = "tcp"
+    security_groups = [aws_security_group.sg.id]
+  }
+
+  ingress {
+    description     = "Inbound rules"
     from_port       = 6666
     to_port         = 6666
     protocol        = "tcp"
@@ -62,6 +70,14 @@ resource "aws_security_group" "privatelink" {
     description     = "Outbound rules"
     from_port       = 443
     to_port         = 443
+    protocol        = "tcp"
+    security_groups = [aws_security_group.sg.id]
+  }
+
+  egress {
+    description     = "Outbound rules"
+    from_port       = 2443
+    to_port         = 2443
     protocol        = "tcp"
     security_groups = [aws_security_group.sg.id]
   }

--- a/aws/tf/provider.tf
+++ b/aws/tf/provider.tf
@@ -2,6 +2,8 @@ terraform {
   required_providers {
     databricks = {
       source = "databricks/databricks"
+      #version = "~> 1.29.0"
+      #current OIDC error in 1.31, uncomment above if you see error
     }
     aws = {
       source = "hashicorp/aws"

--- a/aws/tf/sra.tf
+++ b/aws/tf/sra.tf
@@ -19,7 +19,7 @@ module "SRA" {
   resource_prefix = var.resource_prefix
   resource_owner  = var.resource_owner
   region          = var.region
-  region_name     = var.region_name
+  region_name     = var.region_name[var.region]
 
   // Account-level Variables
   metastore_id           = null // Metastore Configuration - leave null if there is no existing regional metastore
@@ -34,12 +34,12 @@ module "SRA" {
   private_subnets_cidr     = ["10.0.16.0/22", "10.0.24.0/22"]
   privatelink_subnets_cidr = ["10.0.32.0/26", "10.0.32.64/26"]
   public_subnets_cidr      = ["10.0.32.128/26", "10.0.32.192/26"]
-  availability_zones       = ["us-east-1a", "us-east-1b"]
-  sg_egress_ports          = [443, 3306, 6666]
+  availability_zones       = [data.aws_availability_zones.available.names[0], data.aws_availability_zones.available.names[1]]
+  sg_egress_ports          = [443, 2443, 3306, 6666, 8443, 8444, 8445, 8446, 8447, 8448, 8449, 8450, 8451]
   sg_ingress_protocol      = ["tcp", "udp"]
   sg_egress_protocol       = ["tcp", "udp"]
-  relay_vpce_service       = "com.amazonaws.vpce.us-east-1.vpce-svc-00018a8c3ff62ffdf"
-  workspace_vpce_service   = "com.amazonaws.vpce.us-east-1.vpce-svc-09143d1e626de2f04"
+  relay_vpce_service       = var.scc_relay[var.region]
+  workspace_vpce_service   = var.workspace[var.region]
 
   // Optional - IP Access Lists - Set to True to Enable
   enable_ip_boolean = false

--- a/aws/tf/template.tfvars.example
+++ b/aws/tf/template.tfvars.example
@@ -1,0 +1,9 @@
+#copy file and remove .example suffix
+
+aws_account_id        = ""
+client_id             = ""
+client_secret         = ""
+databricks_account_id = ""
+region                = ""
+resource_owner        = ""
+resource_prefix       = ""

--- a/aws/tf/variables.tf
+++ b/aws/tf/variables.tf
@@ -22,13 +22,34 @@ variable "databricks_account_id" {
 }
 
 variable "region" {
-  description = "AWS region code."
+  description = "AWS region code. (e.g. us-east-1)"
   type        = string
+  validation {
+    condition     = contains(["ap-northeast-1", "ap-northeast-2", "ap-south-1", "ap-southeast-1", "ap-southeast-2", "ca-central-1", "eu-central-1", "eu-west-1", "eu-west-2", "eu-west-3", "sa-east-1", "us-east-1", "us-east-2", "us-west-2"], var.region)
+    error_message = "Valid values for var: region are (ap-northeast-1, ap-northeast-2, ap-south-1, ap-southeast-1, ap-southeast-2, ca-central-1, eu-central-1, eu-west-1, eu-west-2, eu-west-3, sa-east-1, us-east-1, us-east-2, us-west-2)."
+  }
 }
 
 variable "region_name" {
-  description = "Name of the AWS region."
-  type        = string
+  description = "Name of the AWS region. (e.g. nvirginia)"
+  type = map(string)
+  default = {
+    "ap-northeast-1" = "tokyo"
+    "ap-northeast-2" = "seoul"
+    "ap-south-1" = "mumbai"
+    "ap-southeast-1" = "singapore"
+    "ap-southeast-2" = "sydney"
+    "ca-central-1" = "canada"
+    "eu-central-1" = "frankfurt"
+    "eu-west-1" = "ireland"
+    "eu-west-2" = "london"
+    "eu-west-3" = "paris"
+    "sa-east-1" = "saopaulo"
+    "us-east-1" = "nvirginia"
+    "us-east-2" = "ohio"
+    "us-west-2" = "oregon"
+    #"us-west-1" = "oregon"
+  }
 }
 
 variable "resource_owner" {
@@ -39,4 +60,50 @@ variable "resource_owner" {
 variable "resource_prefix" {
   description = "Prefix for the resource names."
   type        = string
+}
+
+data "aws_availability_zones" "available" {
+  state = "available"
+}
+
+variable "workspace" {
+  type = map(string)
+  default = {
+    "ap-northeast-1" = "com.amazonaws.vpce.ap-northeast-1.vpce-svc-02691fd610d24fd64"
+    "ap-northeast-2" = "com.amazonaws.vpce.ap-northeast-2.vpce-svc-0babb9bde64f34d7e"
+    "ap-south-1" = "com.amazonaws.vpce.ap-south-1.vpce-svc-0dbfe5d9ee18d6411"
+    "ap-southeast-1" = "com.amazonaws.vpce.ap-southeast-1.vpce-svc-02535b257fc253ff4"
+    "ap-southeast-2" = "com.amazonaws.vpce.ap-southeast-2.vpce-svc-0b87155ddd6954974"
+    "ca-central-1" = "com.amazonaws.vpce.ca-central-1.vpce-svc-0205f197ec0e28d65"
+    "eu-central-1" = "com.amazonaws.vpce.eu-central-1.vpce-svc-081f78503812597f7"
+    "eu-west-1" = "com.amazonaws.vpce.eu-west-1.vpce-svc-0da6ebf1461278016"
+    "eu-west-2" = "com.amazonaws.vpce.eu-west-2.vpce-svc-01148c7cdc1d1326c"
+    "eu-west-3" = "com.amazonaws.vpce.eu-west-3.vpce-svc-008b9368d1d011f37"
+    "sa-east-1" = "com.amazonaws.vpce.sa-east-1.vpce-svc-0bafcea8cdfe11b66"
+    "us-east-1" = "com.amazonaws.vpce.us-east-1.vpce-svc-09143d1e626de2f04"
+    "us-east-2" = "com.amazonaws.vpce.us-east-2.vpce-svc-041dc2b4d7796b8d3"
+    "us-west-2" = "com.amazonaws.vpce.us-west-2.vpce-svc-0129f463fcfbc46c5"
+    #"us-west-1" = ""
+  }
+}
+
+variable "scc_relay" {
+  type = map(string)
+  default = {
+    "ap-northeast-1" = "com.amazonaws.vpce.ap-northeast-1.vpce-svc-02aa633bda3edbec0"
+    "ap-northeast-2" = "com.amazonaws.vpce.ap-northeast-2.vpce-svc-0dc0e98a5800db5c4"
+    "ap-south-1" = "com.amazonaws.vpce.ap-south-1.vpce-svc-03fd4d9b61414f3de"
+    "ap-southeast-1" = "com.amazonaws.vpce.ap-southeast-1.vpce-svc-0557367c6fc1a0c5c"
+    "ap-southeast-2" = "com.amazonaws.vpce.ap-southeast-2.vpce-svc-0b4a72e8f825495f6"
+    "ca-central-1" = "com.amazonaws.vpce.ca-central-1.vpce-svc-0c4e25bdbcbfbb684"
+    "eu-central-1" = "com.amazonaws.vpce.eu-central-1.vpce-svc-08e5dfca9572c85c4"
+    "eu-west-1" = "com.amazonaws.vpce.eu-west-1.vpce-svc-09b4eb2bc775f4e8c"
+    "eu-west-2" = "com.amazonaws.vpce.eu-west-2.vpce-svc-05279412bf5353a45"
+    "eu-west-3" = "com.amazonaws.vpce.eu-west-3.vpce-svc-005b039dd0b5f857d"
+    "sa-east-1" = "com.amazonaws.vpce.sa-east-1.vpce-svc-0e61564963be1b43f"
+    "us-east-1" = "com.amazonaws.vpce.us-east-1.vpce-svc-00018a8c3ff62ffdf"
+    "us-east-2" = "com.amazonaws.vpce.us-east-2.vpce-svc-090a8fab0d73e39a6"
+    "us-west-2" = "com.amazonaws.vpce.us-west-2.vpce-svc-0158114c0c730c3bb"
+    #"us-west-1" = ""
+  }
 }


### PR DESCRIPTION
Added support for ports related to SCC FIPS endpoint, and future reserved control plane communications. Also added maps for Databricks PL VPCes and Restricted S3 policies regional name. Added a data block to pull available AZs.