### PR TITLE
General Clean-Up PR

### DIFF
--- a/aws/README.md
+++ b/aws/README.md
@@ -1,16 +1,19 @@
 # Security Reference Architecture Template
 
+
 ## Introduction
 
 Databricks has worked with thousands of customers to securely deploy the Databricks platform with appropriate security features to meet their architecture requirements.
 
 This Security Reference Architecture (SRA) repository implements common security features as a unified terraform templates that are typically deployed by our security conscious customers.
 
+
 ## Component Breakdown and Description
 
 In this section, we break down each of the components that we've included in this Security Reference Architecture.
 
 In various `.tf` scripts, we have included direct links to the Databricks Terraform documentation. The [official documentation](https://registry.terraform.io/providers/databricks/databricks/latest/docs) can be found here.
+
 
 ## Operation Mode:
 
@@ -26,6 +29,7 @@ There are four separate operation modes you can choose for the underlying networ
 
 See the below networking diagrams for more information.
 
+
 ## Infrastructure Deployment
 
 - **Customer-managed VPC**: A [customer-managed VPC](https://docs.databricks.com/administration-guide/cloud-configurations/aws/customer-managed-vpc.html) allows Databricks customers to exercise more control over network configuration to comply with specific cloud security and governance standards that a customer's organization may require.
@@ -40,9 +44,8 @@ See the below networking diagrams for more information.
 
 - **Unity Catalog**: [Unity Catalog](https://docs.databricks.com/data-governance/unity-catalog/index.html) is a unified governance solution for all data and AI assets including files, tables, and machine learning models. Unity Catalog provides a modern approach to granular access controls with centralized policy, auditing, and lineage tracking - all integrated into your Databricks workflow. **NOTE**: SRA creates a workspace specific catalog that is isolated to that individual workspace. To change these settings please update uc_catalog.tf under the workspace_security_modules.
 
-## Post Workspace Deployment
 
-- **Audit and Billing Log Delivery**: Databricks delivers logs to your S3 buckets. [Audit logs](https://docs.databricks.com/administration-guide/account-settings/audit-logs.html) contain two levels of events: workspace-level audit logs with workspace-level events and account-level audit logs with account-level events. In addition to these logs, you can generate additional events by enabling verbose audit logs. [Billable usage logs](https://docs.databricks.com/administration-guide/account-settings/billable-usage-delivery.html) are delivered daily to an AWS S3 storage bucket. There will be a separate CSV file for each workspace. This file contains historical data about the workspace's cluster usage in Databricks Units (DBUs).
+## Post Workspace Deployment
 
 - **Service Principals**: A [Service principal](https://docs.databricks.com/administration-guide/users-groups/service-principals.html) is an identity that you create in Databricks for use with automated tools, jobs, and applications. It's against best practice to tie production workloads to individual user accounts, and so we recommend configuring these service principals within Databricks. In this template, we create an example service principal.
 
@@ -50,21 +53,25 @@ See the below networking diagrams for more information.
 
 - **Secret Management** Integrating with heterogenous systems requires managing a potentially large set of credentials and safely distributing them across an organization. Instead of directly entering your credentials into a notebook, use [Databricks secrets](https://docs.databricks.com/security/secrets/index.html) to store your credentials and reference them in notebooks and jobs. In this template, we create an example secret.
 
-- **Admin Console Configurations**: There are a number of configurations within the [admin console](https://docs.databricks.com/administration-guide/admin-console.html) that can be controlled to reduce your threat vector. In this example, we use the workspace configurations Terraform template to disable and enable numerous options.
-
-- **Cluster Tags and Pool Tags**: [Cluster and pool tags](https://docs.databricks.com/administration-guide/account-settings/usage-detail-tags-aws.html) allow customers to monitor cost and accurately attribute Databricks usage to your organization's business unit and teams (for chargebacks, for examples). These tags propagate both to detailed DBU usage reports and to AWS EC2 and AWS EBS instances for cost analysis.
 
 ## Optional Deployment Configurations
 
-- **Audit and Billable Usage Logs**: Audit and Billable Usage Logs can be enabled twice across a Databricks account. If your account has logging configured, you can set this parameter to false, so that another logging configuration is created.
-
-- **IP Access Lists**: IP Access can be enabled to only allow a subset of IPs to access the Databricks workspace console. **NOTE:** Please verify all of the IPs are correct prior to enabling this feature to prevent a lockout scenario.
+- **Audit and Billable Usage Logs**: Databricks delivers logs to your S3 buckets. [Audit logs](https://docs.databricks.com/administration-guide/account-settings/audit-logs.html) contain two levels of events: workspace-level audit logs with workspace-level events and account-level audit logs with account-level events. In addition to these logs, you can generate additional events by enabling verbose audit logs. [Billable usage logs](https://docs.databricks.com/administration-guide/account-settings/billable-usage-delivery.html) are delivered daily to an AWS S3 storage bucket. There will be a separate CSV file for each workspace. This file contains historical data about the workspace's cluster usage in Databricks Units (DBUs).
 
 - **Cluster Example**: An example of a cluster and a cluster policy has been included. **NOTE:** Please be aware this will create a cluster within your Databricks workspace including the underlying EC2 instance.
 
-- **Enable Restrictive Root Bucket**: A restrictive root bucket policy can be applied to the root bucket of the workspace. **NOTE:** Please be aware this bucket is updated frequently, however, may not contain prefixes for the latest product releases.
+- **IP Access Lists**: IP Access can be enabled to only allow a subset of IPs to access the Databricks workspace console. **NOTE:** Please verify all of the IPs are correct prior to enabling this feature to prevent a lockout scenario.
 
-- **Enable Restrictive Kinesis, STS, and S3 Endpoint Policies**: Restrictive policies for Kinesis, STS, and S3 endpoints can be added for Databricks specific assets. **NOTE:** Please be aware thse policies could be updated and may result in potentially breaking changes. If this is the case, we recommend removing the policy.
+- **Read Only External Location**: This creates a read-only external location in Unity Catalog for a given bucket as well as the corresponding AWS IAM role.
+
+- **Restrictive Root Bucket**: A restrictive root bucket policy can be applied to the root bucket of the workspace. **NOTE:** Please be aware this bucket is updated frequently, however, may not contain prefixes for the latest product releases.
+
+- **Restrictive Kinesis, STS, and S3 Endpoint Policies**: Restrictive policies for Kinesis, STS, and S3 endpoints can be added for Databricks specific assets. **NOTE:** Please be aware thse policies could be updated and may result in potentially breaking changes. If this is the case, we recommend removing the policy.
+
+- **System Tables**: System tables are a Databricks-hosted analytical store of your account’s operational data found in the system catalog. System tables can be used for historical observability across your account. This is currently in public preview, so is optional to enable or not.
+
+- **Workspace Admin. Configurations**: Workspace administration configurations that can be enabled that align with security best practices. The Terraform resource is experimental, which is why it is optional. Documentation on each configuration is provided in the Terraform file.
+
 
 ## Solution Accelerators
 
@@ -94,27 +101,32 @@ In this section, we break down additional security recommendations and opportuni
 
 - **Evaluate Whether your Workflow requires using Git Repos or CI/CD**: Mature organizations often build production workloads by using CI/CD to integrate code scanning, better control permissions, perform linting, and more. When there is highly sensitive data analyzed, a CI/CD process can also allow scanning for known scenarios such as hard coded secrets.
 
+
 ## Getting Started
 
 1. Clone this Repo
 2. Install [Terraform](https://developer.hashicorp.com/terraform/downloads)
 3. Decide which [operation](https://github.com/databricks/terraform-databricks-sra/tree/main/aws/tf#operation-mode) mode you'd like to use.
 4. Fill out `sra.tf` in place
-5. Fill out `example.tfvars` and place in `tf` directory
+5. Fill out `example.tfvars` and place in `tf` directory, remove the .example part of the file name
 6. CD into `tf`
 7. Run `terraform init`
 8. Run `terraform validate`
 9. From `tf` directory, run `terraform plan -var-file ../example.tfvars`
 10. Run `terraform apply -var-file ../example.tfvars`
 
+
 ## Network Diagram - Sandbox
 ![Architecture Diagram](https://github.com/databricks/terraform-databricks-sra/blob/main/aws/img/Sandbox%20-%20Network%20Topology.png)
+
 
 ## Network Diagram - Firewall
 ![Architecture Diagram](https://github.com/databricks/terraform-databricks-sra/blob/main/aws/img/Firewall%20-%20Network%20Topology.png)
 
+
 ## Network Diagram - Isolated
 ![Architecture Diagram](https://github.com/databricks/terraform-databricks-sra/blob/main/aws/img/Isolated%20-%20Network%20Topology.png)
+
 
 ## FAQ
 

--- a/aws/README.md
+++ b/aws/README.md
@@ -108,7 +108,7 @@ In this section, we break down additional security recommendations and opportuni
 2. Install [Terraform](https://developer.hashicorp.com/terraform/downloads)
 3. Decide which [operation](https://github.com/databricks/terraform-databricks-sra/tree/main/aws/tf#operation-mode) mode you'd like to use.
 4. Fill out `sra.tf` in place
-5. Fill out `example.tfvars` and place in `tf` directory, remove the .example part of the file name
+5. Fill out `template.tfvars.example` remove the .example part of the file name
 6. CD into `tf`
 7. Run `terraform init`
 8. Run `terraform validate`

--- a/aws/tf/modules/sra/cmk.tf
+++ b/aws/tf/modules/sra/cmk.tf
@@ -6,7 +6,8 @@ locals {
 
 resource "aws_kms_key" "workspace_storage" {
   description = "KMS key for databricks workspace storage"
-  policy = jsonencode({ Version : "2012-10-17",
+  policy = jsonencode({
+    Version : "2012-10-17",
     "Id" : "key-policy-workspace-storage",
     Statement : [
       {
@@ -58,13 +59,17 @@ resource "aws_kms_key" "workspace_storage" {
         }
       }
     ]
-    }
-  )
+  })
   depends_on = [aws_iam_role.cross_account_role]
+
+  tags = {
+    Resource = var.resource_prefix
+  }
 }
 
+
 resource "aws_kms_alias" "workspace_storage_key_alias" {
-  name          = "alias/${var.resource_prefix}-workspace-storage-key-alias"
+  name          = "alias/${var.resource_prefix}-workspace-storage-key"
   target_key_id = aws_kms_key.workspace_storage.id
 }
 
@@ -104,9 +109,13 @@ resource "aws_kms_key" "managed_storage" {
     ]
     }
   )
+
+  tags = {
+    Resource = var.resource_prefix
+  }
 }
 
 resource "aws_kms_alias" "managed_storage_key_alias" {
-  name          = "alias/${var.resource_prefix}-managed-storage-key-alias"
+  name          = "alias/${var.resource_prefix}-managed-storage-key"
   target_key_id = aws_kms_key.managed_storage.key_id
 }

--- a/aws/tf/modules/sra/credential.tf
+++ b/aws/tf/modules/sra/credential.tf
@@ -78,21 +78,6 @@ resource "aws_iam_role_policy" "cross_account" {
         } }
       },
       {
-        "Sid" : "AllowEc2RunInstanceImagePerTag",
-        "Effect" : "Allow",
-        "Action" : "ec2:RunInstances",
-        "Resource" : [
-          "arn:aws:ec2:${var.region}:${var.aws_account_id}:image/*"
-        ],
-        "Condition" : {
-          "StringEquals" : {
-            "aws:ResourceTag/Vendor" : "Databricks",
-            "ec2:Owner" : "601306020600"
-          }
-        }
-      }
-      ,
-      {
         "Sid" : "AllowEc2RunInstancePerVPCid",
         "Effect" : "Allow",
         "Action" : "ec2:RunInstances",

--- a/aws/tf/modules/sra/data_plane_hardening.tf
+++ b/aws/tf/modules/sra/data_plane_hardening.tf
@@ -33,9 +33,9 @@ module "restrictive_root_bucket" {
     aws = aws
   }
 
-  workspace_id = module.databricks_mws_workspace.workspace_id
-  region_name  = var.region_name
-  dbfsname     = var.dbfsname
+  workspace_id   = module.databricks_mws_workspace.workspace_id
+  region_name    = var.region_name
+  root_s3_bucket = "${var.resource_prefix}-workspace-root-storage"
 
   depends_on = [module.databricks_mws_workspace]
 }

--- a/aws/tf/modules/sra/data_plane_hardening/restrictive_root_bucket/restrictive_root_bucket.tf
+++ b/aws/tf/modules/sra/data_plane_hardening/restrictive_root_bucket/restrictive_root_bucket.tf
@@ -2,7 +2,7 @@
 
 // Restrictive Bucket Policy
 resource "aws_s3_bucket_policy" "databricks_bucket_restrictive_policy" {
-  bucket = var.dbfsname
+  bucket = var.root_s3_bucket
   policy = jsonencode({
     Version = "2012-10-17",
     Statement = [
@@ -19,8 +19,8 @@ resource "aws_s3_bucket_policy" "databricks_bucket_restrictive_policy" {
           "s3:GetBucketLocation"
         ],
         Resource = [
-          "arn:aws:s3:::${var.dbfsname}/*",
-          "arn:aws:s3:::${var.dbfsname}"
+          "arn:aws:s3:::${var.root_s3_bucket}/*",
+          "arn:aws:s3:::${var.root_s3_bucket}"
         ]
       },
       {
@@ -34,21 +34,21 @@ resource "aws_s3_bucket_policy" "databricks_bucket_restrictive_policy" {
           "s3:DeleteObject"
         ],
         Resource = [
-          "arn:aws:s3:::${var.dbfsname}/${var.region_name}-prod/0_databricks_dev",
-          "arn:aws:s3:::${var.dbfsname}/ephemeral/${var.region_name}-prod/${var.workspace_id}/*",
-          "arn:aws:s3:::${var.dbfsname}/${var.region_name}-prod/${var.workspace_id}.*/*",
-          "arn:aws:s3:::${var.dbfsname}/${var.region_name}-prod/${var.workspace_id}/databricks/init/*/*.sh",
-          "arn:aws:s3:::${var.dbfsname}/${var.region_name}-prod/${var.workspace_id}/user/hive/warehouse/*.db/",
-          "arn:aws:s3:::${var.dbfsname}/${var.region_name}-prod/${var.workspace_id}/user/hive/warehouse/*.db/*-*",
-          "arn:aws:s3:::${var.dbfsname}/${var.region_name}-prod/${var.workspace_id}/user/hive/warehouse/*__PLACEHOLDER__/",
-          "arn:aws:s3:::${var.dbfsname}/${var.region_name}-prod/${var.workspace_id}/user/hive/warehouse/*.db/*__PLACEHOLDER__/",
-          "arn:aws:s3:::${var.dbfsname}/${var.region_name}-prod/${var.workspace_id}/FileStore/*",
-          "arn:aws:s3:::${var.dbfsname}/${var.region_name}-prod/${var.workspace_id}/databricks/mlflow/*",
-          "arn:aws:s3:::${var.dbfsname}/${var.region_name}-prod/${var.workspace_id}/databricks/mlflow-*/*",
-          "arn:aws:s3:::${var.dbfsname}/${var.region_name}-prod/${var.workspace_id}/mlflow-*/*",
-          "arn:aws:s3:::${var.dbfsname}/${var.region_name}-prod/${var.workspace_id}/pipelines/*",
-          "arn:aws:s3:::${var.dbfsname}/${var.region_name}-prod/${var.workspace_id}/local_disk0/tmp/*",
-          "arn:aws:s3:::${var.dbfsname}/${var.region_name}-prod/${var.workspace_id}/tmp/*"
+          "arn:aws:s3:::${var.root_s3_bucket}/${var.region_name}-prod/0_databricks_dev",
+          "arn:aws:s3:::${var.root_s3_bucket}/ephemeral/${var.region_name}-prod/${var.workspace_id}/*",
+          "arn:aws:s3:::${var.root_s3_bucket}/${var.region_name}-prod/${var.workspace_id}.*/*",
+          "arn:aws:s3:::${var.root_s3_bucket}/${var.region_name}-prod/${var.workspace_id}/databricks/init/*/*.sh",
+          "arn:aws:s3:::${var.root_s3_bucket}/${var.region_name}-prod/${var.workspace_id}/user/hive/warehouse/*.db/",
+          "arn:aws:s3:::${var.root_s3_bucket}/${var.region_name}-prod/${var.workspace_id}/user/hive/warehouse/*.db/*-*",
+          "arn:aws:s3:::${var.root_s3_bucket}/${var.region_name}-prod/${var.workspace_id}/user/hive/warehouse/*__PLACEHOLDER__/",
+          "arn:aws:s3:::${var.root_s3_bucket}/${var.region_name}-prod/${var.workspace_id}/user/hive/warehouse/*.db/*__PLACEHOLDER__/",
+          "arn:aws:s3:::${var.root_s3_bucket}/${var.region_name}-prod/${var.workspace_id}/FileStore/*",
+          "arn:aws:s3:::${var.root_s3_bucket}/${var.region_name}-prod/${var.workspace_id}/databricks/mlflow/*",
+          "arn:aws:s3:::${var.root_s3_bucket}/${var.region_name}-prod/${var.workspace_id}/databricks/mlflow-*/*",
+          "arn:aws:s3:::${var.root_s3_bucket}/${var.region_name}-prod/${var.workspace_id}/mlflow-*/*",
+          "arn:aws:s3:::${var.root_s3_bucket}/${var.region_name}-prod/${var.workspace_id}/pipelines/*",
+          "arn:aws:s3:::${var.root_s3_bucket}/${var.region_name}-prod/${var.workspace_id}/local_disk0/tmp/*",
+          "arn:aws:s3:::${var.root_s3_bucket}/${var.region_name}-prod/${var.workspace_id}/tmp/*"
         ]
       },
       {
@@ -57,8 +57,8 @@ resource "aws_s3_bucket_policy" "databricks_bucket_restrictive_policy" {
         Action    = ["s3:*"],
         Principal = "*",
         Resource = [
-          "arn:aws:s3:::${var.dbfsname}/*",
-          "arn:aws:s3:::${var.dbfsname}"
+          "arn:aws:s3:::${var.root_s3_bucket}/*",
+          "arn:aws:s3:::${var.root_s3_bucket}"
         ],
         Condition = {
           Bool = {

--- a/aws/tf/modules/sra/data_plane_hardening/restrictive_root_bucket/variables.tf
+++ b/aws/tf/modules/sra/data_plane_hardening/restrictive_root_bucket/variables.tf
@@ -2,7 +2,7 @@ variable "region_name" {
   type = string
 }
 
-variable "dbfsname" {
+variable "root_s3_bucket" {
   type = string
 }
 

--- a/aws/tf/modules/sra/databricks_account.tf
+++ b/aws/tf/modules/sra/databricks_account.tf
@@ -15,7 +15,7 @@ module "log_delivery" {
 
 // Create Unity Catalog Metastore - No Root Storage
 module "uc_init" {
-  count  = var.metastore_id == null ? 1 : 0
+  count  = var.metastore_exists == false ? 1 : 0
   source = "./databricks_account/uc_init"
   providers = {
     databricks = databricks.mws
@@ -25,7 +25,7 @@ module "uc_init" {
   databricks_account_id = var.databricks_account_id
   resource_prefix       = var.resource_prefix
   region                = var.region
-  metastore_name        = var.metastore_name
+  metastore_name        = join("", [var.resource_prefix, "-", var.region, "-", "uc"])
 }
 
 // Unity Catalog Assignment
@@ -35,7 +35,8 @@ module "uc_assignment" {
     databricks = databricks.mws
   }
 
-  metastore_id = var.metastore_id != null ? var.metastore_id : module.uc_init[0].metastore_id
+  metastore_id = var.metastore_exists ? null : module.uc_init[0].metastore_id
+  region       = var.region
   workspace_id = module.databricks_mws_workspace.workspace_id
   depends_on = [
     module.databricks_mws_workspace
@@ -72,8 +73,8 @@ module "service_principal" {
     databricks = databricks.mws
   }
 
-  created_workspace_id             = module.databricks_mws_workspace.workspace_id
-  workspace_service_principal_name = var.workspace_service_principal_name
+  created_workspace_id                   = module.databricks_mws_workspace.workspace_id
+  workspace_admin_service_principal_name = var.workspace_admin_service_principal_name
 
   depends_on = [
     module.databricks_mws_workspace,

--- a/aws/tf/modules/sra/databricks_account/service_principal/service_principal.tf
+++ b/aws/tf/modules/sra/databricks_account/service_principal/service_principal.tf
@@ -1,7 +1,7 @@
 // Terraform Documentation: https://registry.terraform.io/providers/databricks/databricks/latest/docs/resources/service_principal
 
 resource "databricks_service_principal" "sp" {
-  display_name         = var.workspace_service_principal_name
+  display_name         = var.workspace_admin_service_principal_name
   allow_cluster_create = true
 }
 

--- a/aws/tf/modules/sra/databricks_account/service_principal/variables.tf
+++ b/aws/tf/modules/sra/databricks_account/service_principal/variables.tf
@@ -2,7 +2,7 @@ variable "created_workspace_id" {
   type = string
 }
 
-variable "workspace_service_principal_name" {
+variable "workspace_admin_service_principal_name" {
   description = "Service principal name"
   type        = string
 }

--- a/aws/tf/modules/sra/databricks_account/uc_assignment/uc_assignment.tf
+++ b/aws/tf/modules/sra/databricks_account/uc_assignment/uc_assignment.tf
@@ -1,6 +1,11 @@
 // Metastore Assignment
+
+data "databricks_metastore" "this" {
+  region = var.region
+}
+
 resource "databricks_metastore_assignment" "default_metastore" {
   workspace_id         = var.workspace_id
-  metastore_id         = var.metastore_id
+  metastore_id         = var.metastore_id == null ? data.databricks_metastore.this.id : var.metastore_id
   default_catalog_name = "hive_metastore"
 }

--- a/aws/tf/modules/sra/databricks_account/uc_assignment/variables.tf
+++ b/aws/tf/modules/sra/databricks_account/uc_assignment/variables.tf
@@ -5,3 +5,7 @@ variable "metastore_id" {
 variable "workspace_id" {
   type = string
 }
+
+variable "region" {
+  type = string
+}

--- a/aws/tf/modules/sra/databricks_account/uc_init/uc_init.tf
+++ b/aws/tf/modules/sra/databricks_account/uc_init/uc_init.tf
@@ -2,7 +2,7 @@
 
 // Metastore
 resource "databricks_metastore" "this" {
-  name          = "unity-catalog-${var.resource_prefix}"
+  name          = "${var.resource_prefix}-${var.region}-unity-catalog"
   region        = var.region
   force_destroy = true
 }

--- a/aws/tf/modules/sra/databricks_account/workspace/workspace.tf
+++ b/aws/tf/modules/sra/databricks_account/workspace/workspace.tf
@@ -76,7 +76,6 @@ resource "databricks_mws_customer_managed_keys" "workspace_storage" {
 
 // Private Access Setting Configuration
 resource "databricks_mws_private_access_settings" "pas" {
-  account_id                   = var.databricks_account_id
   private_access_settings_name = "${var.resource_prefix}-PAS"
   region                       = var.region
   public_access_enabled        = true
@@ -85,9 +84,10 @@ resource "databricks_mws_private_access_settings" "pas" {
 
 // Workspace Configuration
 resource "databricks_mws_workspaces" "this" {
-  account_id                               = var.databricks_account_id
-  aws_region                               = var.region
-  workspace_name                           = var.resource_prefix
+  account_id     = var.databricks_account_id
+  aws_region     = var.region
+  workspace_name = var.resource_prefix
+  # deployment_name                          = "development-company-A" // Deployment name for the workspace URL. This is not enabled by default on an account. Please reach out to your Databricks representative for more information.
   credentials_id                           = databricks_mws_credentials.this.credentials_id
   storage_configuration_id                 = databricks_mws_storage_configurations.this.storage_configuration_id
   network_id                               = databricks_mws_networks.this.network_id

--- a/aws/tf/modules/sra/databricks_workspace.tf
+++ b/aws/tf/modules/sra/databricks_workspace.tf
@@ -21,7 +21,7 @@ module "uc_catalog" {
 
 // Create Read-Only Storage Location for Data Bucket & External Location
 module "uc_external_location" {
-  count  = var.enable_read_only_external_location ? 1 : 0
+  count  = var.enable_read_only_external_location_boolean ? 1 : 0
   source = "./databricks_workspace/workspace_security_modules/uc_external_location"
   providers = {
     databricks = databricks.created_workspace
@@ -40,7 +40,7 @@ module "uc_external_location" {
 
 // Workspace Admin Configuration
 module "admin_configuration" {
-  count  = var.enable_admin_configs ? 1 : 0
+  count  = var.enable_admin_configs_boolean ? 1 : 0
   source = "./databricks_workspace/workspace_security_modules/admin_configuration"
   providers = {
     databricks = databricks.created_workspace
@@ -98,9 +98,9 @@ module "cluster_configuration" {
     databricks = databricks.created_workspace
   }
 
-  compliance_security_profile = var.compliance_security_profile
-  secret_config_reference     = module.secret_management.config_reference
-  resource_prefix             = var.resource_prefix
+  compliance_security_profile_egress_ports = var.compliance_security_profile_egress_ports
+  secret_config_reference                  = module.secret_management.config_reference
+  resource_prefix                          = var.resource_prefix
   depends_on = [
     module.databricks_mws_workspace, module.secret_management
   ]
@@ -109,7 +109,7 @@ module "cluster_configuration" {
 // Public Preview - System Table Schemas - Optional
 module "public_preview_system_table" {
   source = "./databricks_workspace/public_preview/system_schema/"
-  count  = var.enable_system_tables_schema ? 1 : 0
+  count  = var.enable_system_tables_schema_boolean ? 1 : 0
   providers = {
     databricks = databricks.created_workspace
   }

--- a/aws/tf/modules/sra/databricks_workspace/workspace_security_modules/cluster_configuration/cluster_configuration.tf
+++ b/aws/tf/modules/sra/databricks_workspace/workspace_security_modules/cluster_configuration/cluster_configuration.tf
@@ -34,7 +34,7 @@ resource "databricks_cluster" "example" {
   cluster_name       = "Shared Cluster"
   data_security_mode = "USER_ISOLATION"
   spark_version      = data.databricks_spark_version.latest_lts.id
-  node_type_id       = var.compliance_security_profile ? "i3en.xlarge" : "i3.xlarge"
+  node_type_id       = var.compliance_security_profile_egress_ports ? "i3en.xlarge" : "i3.xlarge"
   policy_id          = databricks_cluster_policy.example.id
 
   autoscale {

--- a/aws/tf/modules/sra/databricks_workspace/workspace_security_modules/cluster_configuration/variables.tf
+++ b/aws/tf/modules/sra/databricks_workspace/workspace_security_modules/cluster_configuration/variables.tf
@@ -6,7 +6,7 @@ variable "secret_config_reference" {
   type = string
 }
 
-variable "compliance_security_profile" {
+variable "compliance_security_profile_egress_ports" {
   type        = bool
   description = "Add 2443 to security group configuration or nitro instance"
   nullable    = false

--- a/aws/tf/modules/sra/dbfs_s3.tf
+++ b/aws/tf/modules/sra/dbfs_s3.tf
@@ -1,10 +1,10 @@
 // EXPLANATION: Create the workspace root bucket
 
 resource "aws_s3_bucket" "root_storage_bucket" {
-  bucket        = var.dbfsname
+  bucket        = "${var.resource_prefix}-workspace-root-storage"
   force_destroy = true
   tags = {
-    Name = var.dbfsname
+    Name = var.resource_prefix
   }
 }
 

--- a/aws/tf/modules/sra/network.tf
+++ b/aws/tf/modules/sra/network.tf
@@ -7,7 +7,7 @@ module "vpc" {
 
   count = var.operation_mode != "custom" ? 1 : 0
 
-  name = "${var.resource_prefix}-data-plane-VPC"
+  name = "${var.resource_prefix}-classic-compute-plane-vpc"
   cidr = var.vpc_cidr_range
   azs  = var.availability_zones
 
@@ -38,7 +38,7 @@ resource "aws_security_group" "sg" {
   dynamic "ingress" {
     for_each = var.sg_ingress_protocol
     content {
-      description = "Databricks - Data Plane Security Group - Internode Communication"
+      description = "Databricks - Workspace SG - Internode Communication"
       from_port   = 0
       to_port     = 65535
       protocol    = ingress.value
@@ -49,7 +49,7 @@ resource "aws_security_group" "sg" {
   dynamic "egress" {
     for_each = var.sg_egress_protocol
     content {
-      description = "Databricks - Data Plane Security Group - Internode Communication"
+      description = "Databricks - Workspace SG - Internode Communication"
       from_port   = 0
       to_port     = 65535
       protocol    = egress.value
@@ -60,7 +60,7 @@ resource "aws_security_group" "sg" {
   dynamic "egress" {
     for_each = var.sg_egress_ports
     content {
-      description = "Databricks - Data Plane Security Group - REST (443), Secure Cluster Connectivity (6666), Future Extendability (8443-8451)"
+      description = "Databricks - Workspace SG - REST (443), Secure Cluster Connectivity (6666), Future Extendability (8443-8451)"
       from_port   = egress.value
       to_port     = egress.value
       protocol    = "tcp"
@@ -69,10 +69,10 @@ resource "aws_security_group" "sg" {
   }
 
   dynamic "egress" {
-    for_each = var.compliance_security_profile ? [2443] : []
+    for_each = var.compliance_security_profile_egress_ports ? [2443] : []
 
     content {
-      description = "Databricks - Data Plane Security Group -  FIPS encryption"
+      description = "Databricks - Workspace Security Group -  FIPS encryption"
       from_port   = 2443
       to_port     = 2443
       protocol    = "tcp"
@@ -80,6 +80,6 @@ resource "aws_security_group" "sg" {
     }
   }
   tags = {
-    Name = "${var.resource_prefix}-data-plane-sg"
+    Name = "${var.resource_prefix}-workspace-sg"
   }
 }

--- a/aws/tf/modules/sra/privatelink.tf
+++ b/aws/tf/modules/sra/privatelink.tf
@@ -70,8 +70,8 @@ data "aws_iam_policy_document" "s3_vpc_endpoint_policy" {
     }
 
     resources = [
-      "arn:aws:s3:::${var.resource_prefix}-workspace-root-storage}/*",
-      "arn:aws:s3:::${var.resource_prefix}-workspace-root-storage}"
+      "arn:aws:s3:::${var.resource_prefix}-workspace-root-storage/*",
+      "arn:aws:s3:::${var.resource_prefix}-workspace-root-storage"
     ]
 
     condition {

--- a/aws/tf/modules/sra/privatelink.tf
+++ b/aws/tf/modules/sra/privatelink.tf
@@ -29,10 +29,10 @@ resource "aws_security_group" "privatelink" {
   }
 
   dynamic "ingress" {
-    for_each = var.compliance_security_profile ? [2443] : []
+    for_each = var.compliance_security_profile_egress_ports ? [2443] : []
 
     content {
-      description     = "Databricks - Data Plane Security Group -  FIPS encryption"
+      description     = "Databricks - PrivateLink Endpoint SG -  FIPS encryption"
       from_port       = 2443
       to_port         = 2443
       protocol        = "tcp"
@@ -70,8 +70,8 @@ data "aws_iam_policy_document" "s3_vpc_endpoint_policy" {
     }
 
     resources = [
-      "arn:aws:s3:::${var.dbfsname}/*",
-      "arn:aws:s3:::${var.dbfsname}"
+      "arn:aws:s3:::${var.resource_prefix}-workspace-root-storage}/*",
+      "arn:aws:s3:::${var.resource_prefix}-workspace-root-storage}"
     ]
 
     condition {
@@ -267,7 +267,7 @@ module "vpc_endpoints" {
     sts = {
       service             = "sts"
       private_dns_enabled = true
-      subnet_ids          = length(module.vpc[0].intra_subnets) > 0 ? slice(module.vpc[0].intra_subnets, 0, min(2, length(module.vpc[0].intra_subnets))) : []
+      subnet_ids          = module.vpc[0].intra_subnets
       policy              = var.enable_restrictive_sts_endpoint_boolean ? data.aws_iam_policy_document.sts_vpc_endpoint_policy[0].json : null
       tags = {
         Name = "${var.resource_prefix}-sts-vpc-endpoint"
@@ -276,7 +276,7 @@ module "vpc_endpoints" {
     kinesis-streams = {
       service             = "kinesis-streams"
       private_dns_enabled = true
-      subnet_ids          = length(module.vpc[0].intra_subnets) > 0 ? slice(module.vpc[0].intra_subnets, 0, min(2, length(module.vpc[0].intra_subnets))) : []
+      subnet_ids          = module.vpc[0].intra_subnets
       policy              = var.enable_restrictive_kinesis_endpoint_boolean ? data.aws_iam_policy_document.kinesis_vpc_endpoint_policy[0].json : null
       tags = {
         Name = "${var.resource_prefix}-kinesis-vpc-endpoint"
@@ -296,7 +296,7 @@ resource "aws_vpc_endpoint" "backend_rest" {
   service_name        = var.workspace_vpce_service
   vpc_endpoint_type   = "Interface"
   security_group_ids  = [aws_security_group.privatelink[0].id]
-  subnet_ids          = length(module.vpc[0].intra_subnets) > 0 ? slice(module.vpc[0].intra_subnets, 0, min(2, length(module.vpc[0].intra_subnets))) : []
+  subnet_ids          = module.vpc[0].intra_subnets
   private_dns_enabled = true
   depends_on          = [module.vpc.vpc_id]
   tags = {
@@ -312,7 +312,7 @@ resource "aws_vpc_endpoint" "backend_relay" {
   service_name        = var.relay_vpce_service
   vpc_endpoint_type   = "Interface"
   security_group_ids  = [aws_security_group.privatelink[0].id]
-  subnet_ids          = length(module.vpc[0].intra_subnets) > 0 ? slice(module.vpc[0].intra_subnets, 0, min(2, length(module.vpc[0].intra_subnets))) : []
+  subnet_ids          = module.vpc[0].intra_subnets
   private_dns_enabled = true
   depends_on          = [module.vpc.vpc_id]
   tags = {

--- a/aws/tf/modules/sra/root_s3_bucket.tf
+++ b/aws/tf/modules/sra/root_s3_bucket.tf
@@ -38,7 +38,8 @@ resource "aws_s3_bucket_public_access_block" "root_storage_bucket" {
 }
 
 data "databricks_aws_bucket_policy" "this" {
-  bucket = aws_s3_bucket.root_storage_bucket.bucket
+  databricks_e2_account_id =  var.databricks_account_id
+  bucket                   = aws_s3_bucket.root_storage_bucket.bucket
 }
 
 # Bucket policy to use if the restrictive root bucket is set to false

--- a/aws/tf/modules/sra/root_s3_bucket.tf
+++ b/aws/tf/modules/sra/root_s3_bucket.tf
@@ -38,7 +38,7 @@ resource "aws_s3_bucket_public_access_block" "root_storage_bucket" {
 }
 
 data "databricks_aws_bucket_policy" "this" {
-  databricks_e2_account_id =  var.databricks_account_id
+  databricks_e2_account_id = var.databricks_account_id
   bucket                   = aws_s3_bucket.root_storage_bucket.bucket
 }
 

--- a/aws/tf/modules/sra/variables.tf
+++ b/aws/tf/modules/sra/variables.tf
@@ -64,11 +64,6 @@ variable "read_only_data_bucket" {
   type        = string
 }
 
-variable "dbfsname" {
-  description = "Name for Databricks File System (DBFS)."
-  type        = string
-}
-
 variable "enable_audit_log_alerting" {
   description = "Flag to audit log alerting."
   type        = bool
@@ -83,7 +78,7 @@ variable "enable_cluster_boolean" {
   default     = false
 }
 
-variable "enable_read_only_external_location" {
+variable "enable_read_only_external_location_boolean" {
   description = "Flag to enable read only external location"
   type        = bool
   sensitive   = true
@@ -137,7 +132,7 @@ variable "enable_sat_boolean" {
   default     = false
 }
 
-variable "enable_system_tables_schema" {
+variable "enable_system_tables_schema_boolean" {
   description = "Flag for enabling public preview system schema access"
   type        = bool
   sensitive   = true
@@ -168,30 +163,29 @@ variable "ip_addresses" {
   type        = list(string)
 }
 
-variable "metastore_id" {
-  description = "ID for the Unity Catalog metastore."
-  type        = string
-  sensitive   = true
+variable "metastore_exists" {
+  description = "If a metastore exists"
+  type        = bool
 }
 
 variable "operation_mode" {
   type        = string
-  description = "The type of network configuration."
+  description = "The type of Operation Mode for the workspace network configuration."
   nullable    = false
 
   validation {
     condition     = contains(["sandbox", "firewall", "custom", "isolated"], var.operation_mode)
-    error_message = "Invalid network type. Allowed values are: sandbox, firewall, custom, isolated."
+    error_message = "Invalid operation model. Allowed values are: sandbox, firewall, custom, isolated."
   }
 }
 
-variable "compliance_security_profile" {
+variable "compliance_security_profile_egress_ports" {
   type        = bool
   description = "Add 2443 to security group configuration or nitro instance"
   nullable    = false
 }
 
-variable "enable_admin_configs" {
+variable "enable_admin_configs_boolean" {
   type        = bool
   description = "Enable workspace configs"
   nullable    = false
@@ -227,12 +221,6 @@ variable "relay_vpce_service" {
   type        = string
 }
 
-variable "resource_owner" {
-  description = "Owner of the resource."
-  type        = string
-  sensitive   = true
-}
-
 variable "resource_prefix" {
   description = "Prefix for the resource names."
   type        = string
@@ -251,11 +239,6 @@ variable "sg_egress_protocol" {
 variable "sg_ingress_protocol" {
   description = "List of ingress protocols for security groups."
   type        = list(string)
-}
-
-variable "metastore_name" {
-  description = "Name of the Unity Catalog Metastore."
-  type        = string
 }
 
 variable "user_workspace_admin" {
@@ -284,7 +267,7 @@ variable "workspace_vpce_service" {
   type        = string
 }
 
-variable "workspace_service_principal_name" {
+variable "workspace_admin_service_principal_name" {
   description = "Service principle name"
   type        = string
 }

--- a/aws/tf/modules/sra/variables.tf
+++ b/aws/tf/modules/sra/variables.tf
@@ -175,7 +175,7 @@ variable "operation_mode" {
 
   validation {
     condition     = contains(["sandbox", "firewall", "custom", "isolated"], var.operation_mode)
-    error_message = "Invalid operation model. Allowed values are: sandbox, firewall, custom, isolated."
+    error_message = "Invalid operation mode. Allowed values are: sandbox, firewall, custom, isolated."
   }
 }
 

--- a/aws/tf/provider.tf
+++ b/aws/tf/provider.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     databricks = {
       source  = "databricks/databricks"
-      version = "~> 1.35.0"
+      version = "~> 1.46.0"
     }
     aws = {
       source = "hashicorp/aws"
@@ -14,7 +14,6 @@ provider "aws" {
   region = var.region
   default_tags {
     tags = {
-      Owner    = var.resource_owner
       Resource = var.resource_prefix
     }
   }

--- a/aws/tf/sra.tf
+++ b/aws/tf/sra.tf
@@ -1,12 +1,11 @@
 module "SRA" {
   source = "./modules/sra"
-
   providers = {
     databricks.mws = databricks.mws
     aws            = aws
   }
 
-  // Authentication Variables
+  // Common Authentication Variables
   databricks_account_id = var.databricks_account_id
   client_id             = var.client_id
   client_secret         = var.client_secret
@@ -14,76 +13,65 @@ module "SRA" {
   region                = var.region
   region_name           = var.region_name[var.region]
 
-  // Naming and tagging variables:
+  // Naming and Tagging Variables:
   resource_prefix = var.resource_prefix
-  resource_owner  = var.resource_owner
 
-  // Account - general
-  enable_logging_boolean = false // Logging configuration - set to true if you'd like to set-up billing and audit log delivery to an S3 bucket. System tables can be used as an alternative with no set-up.
-  user_workspace_admin   = null  // REQUIRED - Admin workspace user (e.g. firstname.lastname@company.com)
+  // Required Variables:
+  workspace_catalog_admin                = null             // Workspace catalog admin email.
+  user_workspace_admin                   = null             // Workspace admin user email.
+  operation_mode                         = "sandbox"        // Operation mode (sandbox, custom, firewall, isolated).
+  workspace_admin_service_principal_name = "sra-example-sp" // Creates an example admin SP for automation use cases.
+  metastore_exists                       = false            // If a regional metastore exists set to true.
 
-  // Account - Unity Catalog:
-  metastore_id            = null // Metastore configuration - leave null if there is no existing regional metastore, does not create a root storage location
-  metastore_name          = join("", [var.resource_prefix, "-", var.region, "-", "uc"])
-  workspace_catalog_admin = null // REQUIRED - Workspace specific catalogs are created, this user will become an admin of that catalog (e.g. firstname.lastname@company.com)
+  // AWS Specific Variables:
+  cmk_admin_arn                            = null // CMK admin ARN, defaults to the AWS account root user.
+  vpc_cidr_range                           = "10.0.0.0/18"
+  private_subnets_cidr                     = ["10.0.0.0/22", "10.0.4.0/22", "10.0.8.0/22"]
+  privatelink_subnets_cidr                 = ["10.0.28.0/26", "10.0.28.64/26", "10.0.28.128/26"]
+  availability_zones                       = [data.aws_availability_zones.available.names[0], data.aws_availability_zones.available.names[1], data.aws_availability_zones.available.names[2]]
+  sg_egress_ports                          = [443, 3306, 6666, 8443, 8444, 8445, 8446, 8447, 8448, 8449, 8450, 8451]
+  compliance_security_profile_egress_ports = false // Set to true to enable compliance security profile related egress ports (2443)
+  sg_ingress_protocol                      = ["tcp", "udp"]
+  sg_egress_protocol                       = ["tcp", "udp"]
+  relay_vpce_service                       = var.scc_relay[var.region]
+  workspace_vpce_service                   = var.workspace[var.region]
 
-  // Account - Unity Catalog - Data:
-  enable_read_only_external_location = false // Creates a read-only external location and corresponding IAM role, based on the value of the data_bucket variable
-  read_only_data_bucket              = null  //  Accepts an S3 bucket name ("data-bucket")
-  read_only_external_location_admin  = null  //  This user will become an admin of that external location (e.g. firstname.lastname@company.com)
+  // Operation Mode Specific Variables:
+  // Sandbox and Firewall Modes
+  public_subnets_cidr = ["10.0.29.0/26", "10.0.29.64/26", "10.0.29.128/26"]
 
-  // Workspace - operation mode:
-  operation_mode              = "sandbox" // REQUIRED - Accepted values: sandbox, custom, firewall, or isolated. https://github.com/databricks/terraform-databricks-sra/blob/main/aws/tf/README.md#operation-mode
-  compliance_security_profile = false     // REQUIRED - If you are using compliance security profile, please enable this to true. This adds port 2443 (FIPS) as a security group rule.
+  // Firewall Mode Specific:
+  firewall_subnets_cidr       = ["10.0.33.0/26", "10.0.33.64/26", "10.0.33.128/26"]
+  firewall_allow_list         = [".pypi.org", ".cran.r-project.org", ".pythonhosted.org", ".spark-packages.org", ".maven.org", "maven.apache.org", ".storage-download.googleapis.com"]
+  firewall_protocol_deny_list = "IP"
+  hive_metastore_fqdn         = "mdb7sywh50xhpr.chkweekm4xjq.us-east-1.rds.amazonaws.com" // https://docs.databricks.com/en/resources/supported-regions.html#rds-addresses-for-legacy-hive-metastore 
 
-  // Workspace - AWS non-networking variables:
-  dbfsname                         = join("", [var.resource_prefix, "-", var.region, "-", "dbfsroot"])
-  cmk_admin_arn                    = null  // If not provided, the root user of the AWS account is used
-  enable_cluster_boolean           = false // WARNING: Clusters will spin-up Databricks clusters and AWS EC2 instances
-  enable_admin_configs             = false // WARNING: The workspace_conf resource is evolving API that may change from provider to provider. Please review the in-resource documentation (admin_configuration.tf) before enabling.
-  workspace_service_principal_name = "sra-example-sp"
-
-  // Workspace - networking variables (optional if using custom operation mode):
-  vpc_cidr_range           = "10.0.0.0/18"
-  private_subnets_cidr     = ["10.0.16.0/22", "10.0.24.0/22"]
-  privatelink_subnets_cidr = ["10.0.32.0/26", "10.0.32.64/26"]
-  public_subnets_cidr      = ["10.0.32.128/26", "10.0.32.192/26"]
-  availability_zones       = [data.aws_availability_zones.available.names[0], data.aws_availability_zones.available.names[1]]
-  sg_egress_ports          = [443, 3306, 6666, 8443, 8444, 8445, 8446, 8447, 8448, 8449, 8450, 8451]
-  sg_ingress_protocol      = ["tcp", "udp"]
-  sg_egress_protocol       = ["tcp", "udp"]
-  relay_vpce_service       = var.scc_relay[var.region]
-  workspace_vpce_service   = var.workspace[var.region]
-
-  // Workspace - networking variables (required if using custom operation mode):
+  // Custom Mode Specific:
   custom_vpc_id             = null
-  custom_private_subnet_ids = null // list of strings required
+  custom_private_subnet_ids = null // List of custom private subnet IDs required.
   custom_sg_id              = null
   custom_relay_vpce_id      = null
   custom_workspace_vpce_id  = null
 
-  // Workspace - networking variables (required if using firewall operation mode):
-  firewall_subnets_cidr       = ["10.0.33.0/26", "10.0.33.64/26"]
-  firewall_allow_list         = [".pypi.org", ".cran.r-project.org", ".pythonhosted.org", ".spark-packages.org", ".maven.org", "maven.apache.org", ".storage-download.googleapis.com"]
-  firewall_protocol_deny_list = "IP"
-  hive_metastore_fqdn         = "mdb7sywh50xhpr.chkweekm4xjq.us-east-1.rds.amazonaws.com" // https://docs.databricks.com/en/resources/supported-regions.html#rds-addresses-for-legacy-hive-metastore
+  // Optional Features:
+  enable_read_only_external_location_boolean = false // Set to true to enable a read-only external location.
+  read_only_data_bucket                      = null  // S3 bucket name for read-only data.
+  read_only_external_location_admin          = null  // Admin for the external location.
 
-  // Workspace - restrictive AWS asset policies (optional):
+  enable_cluster_boolean       = false // Set to true to create a default Databricks clusters.
+  enable_admin_configs_boolean = false // Set to true to enable optional admin configurations.
+  enable_logging_boolean       = false // Set to true to enable log delivery and creation of related assets (e.g. S3 bucket and IAM role)
+
   enable_restrictive_root_bucket_boolean      = false
   enable_restrictive_s3_endpoint_boolean      = false
   enable_restrictive_sts_endpoint_boolean     = false
   enable_restrictive_kinesis_endpoint_boolean = false
 
-  // Workspace - IP access list (optional):
-  enable_ip_boolean = false
-  ip_addresses      = ["X.X.X.X", "X.X.X.X/XX", "X.X.X.X/XX"] // WARNING: Please validate that IPs entered are correct, recommend setting a break glass IP in case of a lockout
+  enable_ip_boolean = false                                   // Set to true to enable IP access list.
+  ip_addresses      = ["X.X.X.X", "X.X.X.X/XX", "X.X.X.X/XX"] // Specify IP addresses for access.
 
-  // Public Preview - System Tables Schemas (optional, if system tables audit log alerting is set to true and system table schemas are not enabled then it is required):
-  enable_system_tables_schema = false // WARNING: This feature is in public preview: https://docs.databricks.com/en/administration-guide/system-tables/index.html#enable-system-table-schemas
+  enable_system_tables_schema_boolean = false // Set to true to enable system table schemas (Public Preview).
 
-  // Solution Accelerator - Security Analysis Tool (optional):
-  enable_sat_boolean = false // WARNING: Security analysis tool spins-up jobs and clusters. More information here: https://github.com/databricks-industry-solutions/security-analysis-tool/tree/main
-
-  // Solution Accelerator - Audit Logs Alerting (optional):
-  enable_audit_log_alerting = false // WARNING: Audit Logs Alerting spins-up jobs and clusters. More information here: https://github.com/andyweaves/system-tables-audit-logs/tree/main/terraform
+  enable_sat_boolean        = false // Set to true to enable Security Analysis Tool. https://github.com/databricks-industry-solutions/security-analysis-tool
+  enable_audit_log_alerting = false // Set to true to create 40+ queries for audit log alerting based on user activity. https://github.com/andyweaves/system-tables-audit-logs
 }

--- a/aws/tf/sra.tf
+++ b/aws/tf/sra.tf
@@ -21,11 +21,11 @@ module "SRA" {
   user_workspace_admin                   = null             // Workspace admin user email.
   operation_mode                         = "sandbox"        // Operation mode (sandbox, custom, firewall, isolated).
   workspace_admin_service_principal_name = "sra-example-sp" // Creates an example admin SP for automation use cases.
-  metastore_exists                       = false            // If a regional metastore exists set to true.
+  metastore_exists                       = false            // If a regional metastore exists set to true. If there are multiple regional metastores, you can comment out "uc_init" and add the metastore ID directly in to the module call for "uc_assignment".
 
   // AWS Specific Variables:
   cmk_admin_arn                            = null // CMK admin ARN, defaults to the AWS account root user.
-  vpc_cidr_range                           = "10.0.0.0/18"
+  vpc_cidr_range                           = "10.0.0.0/18" // Please re-define the subsequent subnet ranges if the VPC CIDR range is updated.
   private_subnets_cidr                     = ["10.0.0.0/22", "10.0.4.0/22", "10.0.8.0/22"]
   privatelink_subnets_cidr                 = ["10.0.28.0/26", "10.0.28.64/26", "10.0.28.128/26"]
   availability_zones                       = [data.aws_availability_zones.available.names[0], data.aws_availability_zones.available.names[1], data.aws_availability_zones.available.names[2]]

--- a/aws/tf/template.tfvars.example
+++ b/aws/tf/template.tfvars.example
@@ -1,9 +1,8 @@
-#copy file and remove .example suffix
+# Configuration Variables for AWS and Databricks
 
-aws_account_id        = ""
-client_id             = ""
-client_secret         = ""
-databricks_account_id = ""
-region                = ""
-resource_owner        = ""
-resource_prefix       = ""
+aws_account_id = ""        // AWS account ID where resources will be deployed.
+client_id = ""             // Service principal ID for Databricks with admin permissions.
+client_secret = ""         // Secret for the corresponding service principal.
+databricks_account_id = "" // Databricks account ID.
+region = ""                // AWS and Databricks region (e.g., us-west-2).
+resource_prefix = ""       // Prefix used for naming and tagging resources (e.g., S3 buckets, IAM roles).

--- a/aws/tf/variables.tf
+++ b/aws/tf/variables.tf
@@ -52,11 +52,6 @@ variable "region_name" {
   }
 }
 
-variable "resource_owner" {
-  description = "Owner of the resource."
-  type        = string
-}
-
 variable "resource_prefix" {
   description = "Prefix for the resource names."
   type        = string


### PR DESCRIPTION
**General Updates:**

- **Provider Upgrade:** The Databricks provider has been upgraded to 1.46. No impact was seen in usage from 1.46 to the previous version. However, if you're managing an active environment, you should do your own testing in your lower environments.

- **README:** Moved the readme to the top level of the AWS repository for easier access, isolating the relevant Terraform code. Cleaned-up the **Post Workspace Deployment** to only include modules that are deployed by default. All optional modes are outlined in **Optional Deployment Configuration.**

- **Metastore Creation:**
    - Metastore ID variable has been removed. Now it is a boolean value if metastore exists or not in the region. If a metastore exists for that region, then the new workspace will be attached. This will have an impact to the very small percentage of accounts that have multiple metastores in the same region. They can directly add the metastore ID in the metastore assignment TF file. This addresses this issue #67 

- **Variable Updates:** 
    - **Booleans in variables names:** Any optional variable that is true or false now has the same naming convention. Like enable_read_only_external_location_boolean, enable_admin_configs_boolean, etc.
    - **dbfsname variable:** Removed DBFS name as variable to insert. This is now created based on the resource prefix. It is now renamed as "root_s3_bucket" throughout the codebase for additional clarity.
    - **Workspace admin service principal variable:** This is now includes _admin_ in the name to represent to permission level of this created SP.
    - **Compliance security profile egress ports:** This has been renamed to better describe it's functionality now that a compliance security profile resource exists. This enablement only impacts the outbound ports on the workspace SG and inbound ports on the PrivateLink.
    - **Error message on operation_mode:** Updated the error message so it no longer says network type.

- **template.tfvars.example:**
    - The template file now has comments on what values to provide for each of the values for clarity.

**Individual Files:**

- **sra.tf:**
   - The main file has been cleaned up and organized based on required variables, operation mode, and the optional modules that can be enabled on a deployment.
   - Made the default amount of subnets to three instead of two to increase the high availability of the workspace, which is more applicable to production use cases. 

- **networking.tf:**
   - VPC has been renamed from 'data plane' to 'classic compute plane' for clarity
   - Workspace security group has been renamed from 'data plane security group' to 'workspace SG' for clarity

- **privatelink.tf:**
    - Fixed an issue around PrivateLink endpoints not being applied to all availability zones if more than two subnets were provided in the variables.

- **cmk.tf:**
    - Added tags for both the workspace storage and managed key.

- **credential.tf**
   - Removed redundant allow block image resource with the condition key of the Databricks account ID. This is covered by the explicit denied that was added in a [previous commit](https://github.com/databricks/terraform-databricks-sra/commit/11c47190193b5cc1d52746cbebb83ea5b3a2dd92).

- **workspace.tf**
    - Added a commented out deployment_name in the workspace resource configuration. This is not a feature available to all accounts, so this can be commented out and added as a variable for applicable customers.



