### PR TITLE
"refactored Nathan's Private DBFS & added conditionals"

### DIFF
--- a/azure/tf/modules/azure_spoke/dbfs_privatelink.tf
+++ b/azure/tf/modules/azure_spoke/dbfs_privatelink.tf
@@ -1,83 +1,101 @@
-# # Define a private DNS zone for the dbfs_dfs resource
-# resource "azurerm_private_dns_zone" "dbfs_dfs" {
-#   name                = "privatelink.dfs.core.windows.net"
-#   resource_group_name = azurerm_resource_group.this.name
+# Define a private DNS zone for the dbfs_dfs resource
+resource "azurerm_private_dns_zone" "dbfs_dfs" {
+  count = var.boolean_create_private_dbfs ? 1 : 0
 
-#   tags = var.tags
-# }
+  name                = "privatelink.dfs.core.windows.net"
+  resource_group_name = azurerm_resource_group.this.name
 
-# # Define a private endpoint for the dbfs_dfs resource
-# resource "azurerm_private_endpoint" "dbfs_dfs" {
-#   name                = "dbfspe-dfs"
-#   location            = azurerm_resource_group.this.location
-#   resource_group_name = azurerm_resource_group.this.name
-#   subnet_id           = azurerm_subnet.privatelink.id
+  tags = var.tags
+  depends_on = [ azurerm_databricks_workspace.this ]
+}
 
-#   # Define the private service connection for the dbfs_dfs resource
-#   private_service_connection {
-#     name                           = "ple-${var.prefix}-dbfs-dfs"
-#     private_connection_resource_id = join("", [azurerm_databricks_workspace.this.managed_resource_group_id, "/providers/Microsoft.Storage/storageAccounts/", local.dbfs_name])
-#     is_manual_connection           = false
-#     subresource_names              = ["dfs"]
-#   }
+# Define a private endpoint for the dbfs_dfs resource
+resource "azurerm_private_endpoint" "dbfs_dfs" {
+  count = var.boolean_create_private_dbfs ? 1 : 0
 
-#   # Associate the private DNS zone with the private endpoint
-#   private_dns_zone_group {
-#     name                 = "private-dns-zone-dbfs"
-#     private_dns_zone_ids = [azurerm_private_dns_zone.dbfs_dfs.id]
-#   }
+  name                = "dbfspe-dfs"
+  location            = azurerm_resource_group.this.location
+  resource_group_name = azurerm_resource_group.this.name
+  subnet_id           = azurerm_subnet.privatelink.id
 
-#   tags = var.tags
-# }
+  # Define the private service connection for the dbfs_dfs resource
+  private_service_connection {
+    name                           = "ple-${var.prefix}-dbfs-dfs"
+    private_connection_resource_id = join("", [azurerm_databricks_workspace.this.managed_resource_group_id, "/providers/Microsoft.Storage/storageAccounts/", local.dbfs_name])
+    is_manual_connection           = false
+    subresource_names              = ["dfs"]
+  }
 
-# # Define a virtual network link for the dbfs_dfs private DNS zone
-# resource "azurerm_private_dns_zone_virtual_network_link" "dbfs_dfs" {
-#   name                  = "dbfs-dfs"
-#   resource_group_name   = azurerm_resource_group.this.name
-#   private_dns_zone_name = azurerm_private_dns_zone.dbfs_dfs.name
-#   virtual_network_id    = azurerm_virtual_network.this.id
+  # Associate the private DNS zone with the private endpoint
+  private_dns_zone_group {
+    name                 = "private-dns-zone-dbfs"
+    private_dns_zone_ids = [azurerm_private_dns_zone.dbfs_dfs.id]
+  }
 
-#   tags = var.tags
-# }
+  tags = var.tags
+  depends_on = [ azurerm_databricks_workspace.this ]
+}
 
-# # Define a private endpoint for the dbfs_blob resource
-# resource "azurerm_private_endpoint" "dbfspe_blob" {
-#   name                = "dbfs-blob"
-#   location            = azurerm_resource_group.this.location
-#   resource_group_name = azurerm_resource_group.this.name
-#   subnet_id           = azurerm_subnet.privatelink.id
+# Define a virtual network link for the dbfs_dfs private DNS zone
+resource "azurerm_private_dns_zone_virtual_network_link" "dbfs_dfs" {
+  count = var.boolean_create_private_dbfs ? 1 : 0
 
-#   # Define the private service connection for the dbfs_blob resource
-#   private_service_connection {
-#     name                           = "ple-${var.prefix}-dbfs-blob"
-#     private_connection_resource_id = join("", [azurerm_databricks_workspace.this.managed_resource_group_id, "/providers/Microsoft.Storage/storageAccounts/", local.dbfs_name])
-#     is_manual_connection           = false
-#     subresource_names              = ["blob"]
-#   }
+  name                  = "dbfs-dfs"
+  resource_group_name   = azurerm_resource_group.this.name
+  private_dns_zone_name = azurerm_private_dns_zone.dbfs_dfs.name
+  virtual_network_id    = azurerm_virtual_network.this.id
 
-#   # Associate the private DNS zone with the private endpoint
-#   private_dns_zone_group {
-#     name                 = "private-dns-zone-dbfs"
-#     private_dns_zone_ids = [azurerm_private_dns_zone.dbfs_blob.id]
-#   }
+  tags = var.tags
+  depends_on = [ azurerm_databricks_workspace.this ]
+}
 
-#   tags = var.tags
-# }
+# Define a private endpoint for the dbfs_blob resource
+resource "azurerm_private_endpoint" "dbfspe_blob" {
+  count = var.boolean_create_private_dbfs ? 1 : 0
 
-# # Define a private DNS zone for the dbfs_blob resource
-# resource "azurerm_private_dns_zone" "dbfs_blob" {
-#   name                = "privatelink.blob.core.windows.net"
-#   resource_group_name = azurerm_resource_group.this.name
+  name                = "dbfs-blob"
+  location            = azurerm_resource_group.this.location
+  resource_group_name = azurerm_resource_group.this.name
+  subnet_id           = azurerm_subnet.privatelink.id
 
-#   tags = var.tags
-# }
+  # Define the private service connection for the dbfs_blob resource
+  private_service_connection {
+    name                           = "ple-${var.prefix}-dbfs-blob"
+    private_connection_resource_id = join("", [azurerm_databricks_workspace.this.managed_resource_group_id, "/providers/Microsoft.Storage/storageAccounts/", local.dbfs_name])
+    is_manual_connection           = false
+    subresource_names              = ["blob"]
+  }
 
-# # Define a virtual network link for the dbfs_blob private DNS zone
-# resource "azurerm_private_dns_zone_virtual_network_link" "dbfs_blob" {
-#   name                  = "dbfs-blob"
-#   resource_group_name   = azurerm_resource_group.this.name
-#   private_dns_zone_name = azurerm_private_dns_zone.dbfs_blob.name
-#   virtual_network_id    = azurerm_virtual_network.this.id
+  # Associate the private DNS zone with the private endpoint
+  private_dns_zone_group {
+    name                 = "private-dns-zone-dbfs"
+    private_dns_zone_ids = [azurerm_private_dns_zone.dbfs_blob.id]
+  }
 
-#   tags = var.tags
-# }
+  tags = var.tags
+  depends_on = [ azurerm_databricks_workspace.this ]
+}
+
+# Define a private DNS zone for the dbfs_blob resource
+resource "azurerm_private_dns_zone" "dbfs_blob" {
+  count = var.boolean_create_private_dbfs ? 1 : 0
+  
+  name                = "privatelink.blob.core.windows.net"
+  resource_group_name = azurerm_resource_group.this.name
+
+  tags = var.tags
+  depends_on = [ azurerm_databricks_workspace.this ]
+}
+
+# Define a virtual network link for the dbfs_blob private DNS zone
+resource "azurerm_private_dns_zone_virtual_network_link" "dbfs_blob" {
+  count = var.boolean_create_private_dbfs ? 1 : 0
+
+  name                  = "dbfs-blob"
+  resource_group_name   = azurerm_resource_group.this.name
+  private_dns_zone_name = azurerm_private_dns_zone.dbfs_blob.name
+  virtual_network_id    = azurerm_virtual_network.this.id
+
+  tags = var.tags
+  depends_on = [ azurerm_databricks_workspace.this ]
+}

--- a/azure/tf/modules/azure_spoke/variables.tf
+++ b/azure/tf/modules/azure_spoke/variables.tf
@@ -106,3 +106,10 @@ variable "tenant_id" {
   type        = string
   description = "(Required) The tenant ID for the Azure subscription"
 }
+
+# Resource placeholder that checks to see if private_dbfs should be created
+variable "boolean_create_private_dbfs" {
+  description = "Whether to enable Private DBFS, all Private DBFS resources will depend on Workspace"
+  type        = bool
+  default     = true
+}


### PR DESCRIPTION
I added a boolean variable in the [azure/tf/modules/azure_spoke/variables.tf](https://github.com/databricks/terraform-databricks-sra/commit/37d90a68462de4cf86975bf4c1914d2e7afa2791#diff-06f8822324e4ce3b98a9a3d5475a0861bcd2409801a11c6f20b0b950fce636c3) (default is true) for implementing private dbfs 

Fortunately @nathanknox already had the private dbfs terraform code in the Azure SRA folder. I uncommented the `azure/tf/modules/azure_spoke/dbfs_privatelink.tf` file and added the following conditionals.
Each block in the [azure/tf/modules/azure_spoke/dbfs_privatelink.tf](https://github.com/databricks/terraform-databricks-sra/commit/37d90a68462de4cf86975bf4c1914d2e7afa2791#diff-8dcc0ff577329f44b081a7b7f2757366826a36ec5a9f4e58a40ed1c9ca61f4a8) will have:
```
count = var.boolean_create_private_dbfs ? 1 : 0
depends_on = [ azurerm_databricks_workspace.this ]
```

The first line checks if the variable `boolean_create_private_dbfs` is set to true (default) or false. Leaving as default or setting to explicit true in the *.tfvars will create all the private dbfs resources as long as the `azurerm_databricks_workspace.this` dependency is complete. 