### PR TITLE
Gcp update - Optional Segregated Network operations

### DIFF
--- a/gcp/modules/workspace_deployment/cmek.tf
+++ b/gcp/modules/workspace_deployment/cmek.tf
@@ -20,16 +20,17 @@ resource "google_kms_crypto_key" "databricks_key" {
 
 
 
-
 # # assign CMEK on Databricks side
 resource "databricks_mws_customer_managed_keys" "this" {
+        
         provider = databricks.accounts
         account_id   = var.databricks_account_id
         gcp_key_info {
-            kms_key_id   = google_kms_crypto_key.databricks_key[0].id 
+            kms_key_id   = var.use_existing_cmek? "projects/${var.google_project}/locations/${var.google_region}/keyRings/${var.keyring_name}/cryptoKeys/${var.key_name}": google_kms_crypto_key.databricks_key[0].id
         }
         use_cases = ["STORAGE","MANAGED","MANAGED_SERVICES"]
         lifecycle {
               ignore_changes = all
         }
 }
+

--- a/gcp/modules/workspace_deployment/init.tf
+++ b/gcp/modules/workspace_deployment/init.tf
@@ -2,14 +2,11 @@ variable "databricks_account_id" {}
 variable "databricks_google_service_account" {}
 variable "google_project" {}
 variable "google_region" {}
+# variable "google_zone" {}
 
 variable "workspace_pe" {}
 variable "relay_pe" {}
 
-variable "use_existing_cmek" {}
-variable "key_name" {}
-variable "keyring_name" {}
-variable "cmek_resource_id" {}
 
 variable "account_console_url" {}
 
@@ -19,6 +16,15 @@ variable "google_pe_subnet" {}
 # Private ip address assigned to PSC endpoints
 variable "relay_pe_ip_name" {}
 variable "workspace_pe_ip_name" {}
+
+# For the value of the regional Hive Metastore IP, refer to the Databricks documentation
+# Here - https://docs.gcp.databricks.com/en/resources/ip-domain-region.html
+variable "hive_metastore_ip" {}
+
+variable "use_existing_cmek" {}
+variable "key_name" {}
+variable "keyring_name" {}
+
 
 variable "google_pe_subnet_ip_cidr_range" {
   default = "10.3.0.0/24"
@@ -43,16 +49,48 @@ variable "mws_workspace_gke_master_ip_range" {
   default = "10.3.0.0/28"
 }
 
-//Users can connect to workspace only from this list of IP's
+variable "use_existing_vpc" {
+  default = false
+}
+variable "existing_vpc_name" {
+  default = ""
+}
+variable "existing_subnet_name" {
+  default = ""
+}
+variable "existing_pod_range_name"{
+  default = ""
+}
+variable "existing_service_range_name"{
+  default = ""
+}
+
+variable "use_existing_PSC_EP" {
+  default = false
+}
+
+
+variable "harden_network" {
+  # Flag to enable Firewall setup by the current module
+  default = true
+}
+
+
+//Users can connect to workspace only thes list of IP's
 variable "ip_addresses" {
   type = list(string)
 }
 
-// Regional value for the Hive Metastore IP (allowing Egress to this public IP)
-variable "hive_metastore_ip" {
-  default = "34.76.244.202"
+variable "cmek_resource_id" {
+  default = ""
 }
-
+variable "use_existing_pas" {}
+variable "existing_pas_id" {
+  default = ""
+}
+variable "workspace_name" {
+  default = "tf-demo-test"
+}
 
 
 
@@ -72,7 +110,8 @@ terraform {
     }
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.2.0"
+      version = ">=5.43.1"
+
     }
   }
 }
@@ -80,6 +119,8 @@ terraform {
 provider "google" {
   project = var.google_project
   region  = var.google_region
+  impersonate_service_account = var.databricks_google_service_account
+  # zone    = var.google_zone
 }
 
 // initialize provider in "accounts" mode to provision new workspace
@@ -123,7 +164,8 @@ resource "databricks_user" "me" {
 
 
  provider  = databricks.workspace
- user_name = data.google_client_openid_userinfo.me.email
+#  user_name = data.google_client_openid_userinfo.me.email
+ user_name = "aleksander.callebat@databricks.com"
 }
 
 

--- a/gcp/modules/workspace_deployment/vpc-firewall.tf
+++ b/gcp/modules/workspace_deployment/vpc-firewall.tf
@@ -1,4 +1,5 @@
 resource "google_compute_firewall" "deny_egress" {
+  count = var.harden_network ? 1 : 0
   name                    = "deny-egress-${google_compute_network.dbx_private_vpc.name}"
   direction               = "EGRESS"
   priority                = 1100
@@ -15,6 +16,7 @@ resource "google_compute_firewall" "deny_egress" {
 # This is the only Egress rule that goes to a public internet IP
 # It can be avoided if the workspace is UC-enabled and that the spark config is configured to avoid fetching the metastore IP
 resource "google_compute_firewall" "to_databricks_managed_hive" {
+  count = var.harden_network ? 1 : 0
   name                    = "to-databricks-managed-hive-${google_compute_network.dbx_private_vpc.name}"
   direction               = "EGRESS"
   priority                = 1010
@@ -28,6 +30,7 @@ resource "google_compute_firewall" "to_databricks_managed_hive" {
 }
 
 resource "google_compute_firewall" "to_gke_health_checks" {
+  count = var.harden_network ? 1 : 0
   name                    = "to-gke-health-checks-${google_compute_network.dbx_private_vpc.name}"
   direction               = "EGRESS"
   priority                = 1010
@@ -41,6 +44,7 @@ resource "google_compute_firewall" "to_gke_health_checks" {
 }
 
 resource "google_compute_firewall" "from_gke_health_checks" {
+  count = var.harden_network ? 1 : 0
   name                    = "from-gke-health-checks-${google_compute_network.dbx_private_vpc.name}"
   direction               = "INGRESS"
   priority                = 1010
@@ -54,6 +58,7 @@ resource "google_compute_firewall" "from_gke_health_checks" {
 }
 
 resource "google_compute_firewall" "to_gke_cp" {
+  count = var.harden_network ? 1 : 0
   name                    = "to-gke-cp-${google_compute_network.dbx_private_vpc.name}"
   direction               = "EGRESS"
   priority                = 1010
@@ -67,6 +72,7 @@ resource "google_compute_firewall" "to_gke_cp" {
 }
 
 resource "google_compute_firewall" "to_google_apis" {
+  count = var.harden_network ? 1 : 0
   name                    = "to-google-apis-${google_compute_network.dbx_private_vpc.name}"
   direction               = "EGRESS"
   priority                = 1010
@@ -79,6 +85,7 @@ resource "google_compute_firewall" "to_google_apis" {
 }
 
 resource "google_compute_firewall" "to_gke_nodes_subnet" {
+  count = var.harden_network ? 1 : 0
   name                    = "to-gke-nodes-subnet-${google_compute_network.dbx_private_vpc.name}"
   direction               = "EGRESS"
   priority                = 1010


### PR DESCRIPTION
In this update, I'm bringing a lot of optional flags. The overall experience doesn't change if you leave the default parameters, but based on past experience I noticed often the team deploying Databricks doesn't have network admin, and requires to raise a ticket in order to prepare the Network and CMEK resources.

Solution : put all the provisioning of these resources behind flags, so that the team with lower privileges can request the artefacts to be created, and then deploy their Databricks how they want

Stability test : 
<img width="1324" alt="image" src="https://github.com/user-attachments/assets/a23867e6-5fa8-4e00-86e2-f9b76cb5683b">
