### PR TITLE
Remove Billing System Schema

### DIFF
--- a/aws-gov/tf/modules/sra/databricks_workspace/system_schema/system_schema.tf
+++ b/aws-gov/tf/modules/sra/databricks_workspace/system_schema/system_schema.tf
@@ -4,10 +4,6 @@ resource "databricks_system_schema" "access" {
   schema = "access"
 }
 
-resource "databricks_system_schema" "billing" {
-  schema = "billing"
-}
-
 resource "databricks_system_schema" "compute" {
   schema = "compute"
 }

--- a/aws/tf/modules/sra/databricks_workspace/system_schema/system_schema.tf
+++ b/aws/tf/modules/sra/databricks_workspace/system_schema/system_schema.tf
@@ -4,10 +4,6 @@ resource "databricks_system_schema" "access" {
   schema = "access"
 }
 
-resource "databricks_system_schema" "billing" {
-  schema = "billing"
-}
-
 resource "databricks_system_schema" "compute" {
   schema = "compute"
 }


### PR DESCRIPTION
Billing Schema is now enabled by default. These lines of code cause an error with the following message:

> Cannot create system schema: billing system schema can only be enabled by Databricks.

Removing them fixes the issue.