### PR TITLE
Patch reference architecture diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # Security Reference Architectures (SRA) - Terraform Templates
 
-![SRA Diagram]("https://i.ibb.co/NrfH2qc/Screenshot-2024-09-17-at-1-02-06-PM.png")
-
+<p align="center">
+  <img src="https://i.postimg.cc/hP90xPqh/SRA-Screenshot.png" />
+</p>
 
 ## Project Overview
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 # Security Reference Architectures (SRA) - Terraform Templates
 
-<p align="center">
-  <img src="https://i.ibb.co/NrfH2qc/Screenshot-2024-09-17-at-1-02-06-PM.png" />
-</p>
+![SRA Diagram]("https://i.ibb.co/NrfH2qc/Screenshot-2024-09-17-at-1-02-06-PM.png")
+
 
 ## Project Overview
 


### PR DESCRIPTION
Image was truncated on repo for some reason (I'm not sure why) so I uploaded it to a different screenshot website

Before:
<img width="965" alt="image" src="https://github.com/user-attachments/assets/f87f940f-9fd5-4c33-9f22-cfae6b472377" />

After:
<img width="911" alt="image" src="https://github.com/user-attachments/assets/fa0c9501-6f2e-4647-9bf2-5f8694ce411b" />
