### PR TITLE
[AWS] Upgrade provider, remove apache derby configs, update references, remove variables, update policy

### DIFF
--- a/aws/README.md
+++ b/aws/README.md
@@ -6,7 +6,7 @@ SRA is a purpose-built, simplified deployment pattern designed for highly secure
 
 This architecture includes specific functionalities that may affect certain use cases, as outlined below.
 
-- **No outbound internet traffic**: There is no outbound internet from the classic compute plane, meaning there is no access to public package repositories, public APIs, and [Apache Derby](https://kb.databricks.com/metastore/set-up-embedded-metastore) configurations must be used on every classic compute cluster.
+- **No outbound internet traffic**: There is no outbound internet from the classic compute plane, meaning there is no access to public package repositories, public APIs, and Unity Catalog only mode configurations must be set on each cluster or configured at the workspace admin level, official documentation [here](https://docs.databricks.com/aws/en/data-governance/unity-catalog/disable-hms).
     - To add packages to classic compute plane clusters, set up a private repository for scanned packages.
     - Consider using a modern firewall solution to connect to public API endpoints.
     - An example cluster is provided with the correct Apache Derby configurations.
@@ -39,7 +39,7 @@ Various `.tf` scripts contain direct links to the Databricks Terraform documenta
 Choose from two network configurations for your workspaces: **isolated** or **custom**.
 
 - **Isolated (Default)**: Opting for 'isolated' prevents any traffic to the public internet, limiting traffic to AWS private endpoints for AWS services or the Databricks control plane.
-   - **NOTE**: Apache Derby Metastore will be required for clusters and non-serverless SQL Warehouses. For more information, view this [knowledge article](https://kb.databricks.com/metastore/set-up-embedded-metastore).
+   - **NOTE**: A Unity Catalog only configuration is required for any clusters running without access to the public internet. Please see official documentation [here](https://docs.databricks.com/aws/en/data-governance/unity-catalog/disable-hms).
 
 - **Custom**: Selecting 'custom' allows you to specify your own VPC ID, subnet IDs, security group IDs, and PrivateLink endpoint IDs. This mode is recommended when networking assets are created in different pipelines or pre-assigned by a centralized infrastructure team.
 
@@ -57,9 +57,9 @@ Choose from two network configurations for your workspaces: **isolated** or **cu
 
 - **AWS VPC Endpoints for S3, STS, and Kinesis**: Using AWS PrivateLink, a VPC endpoint connects a customer's VPC endpoint to AWS services without traversing public IP addresses. [S3, STS, and Kinesis endpoints](https://docs.databricks.com/administration-guide/cloud-configurations/aws/privatelink.html#step-5-add-vpc-endpoints-for-other-aws-services-recommended-but-optional) are best practices for enterprise Databricks deployments. Additional endpoints can be configured based on your use case (e.g., Amazon DynamoDB and AWS Glue).
 
-- **Back-end AWS PrivateLink Connectivity**: AWS PrivateLink provides a private network route from one AWS environment to another. [Back-end PrivateLink](https://docs.databricks.com/administration-guide/cloud-configurations/aws/privatelink.html#overview) is configured so communication between the customer's data plane and the Databricks control plane does not traverse public IP addresses. This is accomplished through Databricks-specific interface VPC endpoints. Front-end PrivateLink is also available for customers to keep user traffic over the AWS backbone, though front-end PrivateLink is not included in this Terraform template.
+- **Back-end AWS PrivateLink Connectivity**: AWS PrivateLink provides a private network route from one AWS environment to another. [Back-end PrivateLink](https://docs.databricks.com/administration-guide/cloud-configurations/aws/privatelink.html#overview) is configured so communication between the customer's classic compute plane and the Databricks control plane does not traverse public IP addresses. This is accomplished through Databricks-specific interface VPC endpoints. Front-end PrivateLink is also available for customers to keep user traffic over the AWS backbone, though front-end PrivateLink is not included in this Terraform template.
 
-- **Scoped-down IAM Policy for the Databricks cross-account role**: A [cross-account role](https://docs.databricks.com/administration-guide/account-api/iam-role.html) is needed for users, jobs, and other third-party tools to spin up Databricks clusters within the customer's data plane environment. This role can be scoped down to function only within the data plane's VPC, subnets, and security group.
+- **Scoped-down IAM Policy for the Databricks cross-account role**: A [cross-account role](https://docs.databricks.com/administration-guide/account-api/iam-role.html) is needed for users, jobs, and other third-party tools to spin up Databricks clusters within the customer's classic compute plane. This role can be scoped down to function only within the classic compute plane's VPC, subnets, and security group.
 
 - **AWS KMS Keys**: Three AWS KMS keys are created to support the following functionalities:
     - [Workspace Storage](https://docs.databricks.com/en/security/keys/customer-managed-keys.html#customer-managed-keys-for-workspace-storage)
@@ -72,9 +72,10 @@ Choose from two network configurations for your workspaces: **isolated** or **cu
 
 - **System Tables Schemas**: [System Tables](https://docs.databricks.com/en/admin/system-tables/index.html) provide visibility into access, billing, compute, Lakeflow, query, serving, and storage logs. These tables can be found within the system catalog in Unity Catalog.
 
-- **Cluster Example**: An example cluster and cluster policy have been included with Derby Metastore configurations. **NOTE:** This will create a cluster within your Databricks workspace, including the underlying EC2 instance.
+- **Cluster Example**: An example cluster and cluster policy have been included with Unity Catalog only mode configurations. **NOTE:** This will create a cluster within your Databricks workspace, including the underlying EC2 instance.
 
-- **Audit Log Delivery**: Low-latency delivery of Databricks logs to a S3 bucket in your AWS account. [Audit logs](https://docs.databricks.com/aws/en/admin/account-settings/audit-log-delivery) contain two levels of events: workspace-level audit logs with workspace-level events, and account-level audit logs with account-level events. Additionally, you can generate more detailed events by enabling verbose audit logs. 
+- **Audit Log Delivery**: Low-latency delivery of Databricks logs to an S3 bucket in your AWS account. [Audit logs](https://docs.databricks.com/aws/en/admin/account-settings/audit-log-delivery) contain two levels of events: workspace-level audit logs with workspace-level events, and account-level audit logs with account-level events. Additionally, you can generate more detailed events by enabling verbose audit logs. 
+   - **NOTE**: Audit log delivery can only be configured twice for a single account. It's recommended that once it is configured, set *audit_log_delivery_exists* = *false* for subsequent runs.
 
 ---
 
@@ -86,7 +87,7 @@ Choose from two network configurations for your workspaces: **isolated** or **cu
 
 - **Implement Single Sign-On, Multi-factor Authentication, SCIM Provisioning**: Most enterprise deployments enable [Single Sign-On (SSO)](https://docs.databricks.com/administration-guide/users-groups/single-sign-on/index.html) and multi-factor authentication (MFA). For user management, we recommend integrating [SCIM (System for Cross-domain Identity Management)](https://docs.databricks.com/dev-tools/api/latest/scim/index.html) with your account console.
 
-- **Implement Restrictive Serverless Network Policy**: Serverless network policies can be found under Cloud resources, Network, in the account console. A network policy implements an egress firewall for your serverless compute. If you're using the Security Analysis Tool, be sure to allow list the Databricks account console and relevant Databricks workspace endpoints.
+- **Implement Restrictive Serverless Network Policy**: Serverless network policies can be found under Cloud resources, Network, in the account console. A network policy implements an egress firewall for your serverless compute. If you're using the Security Analysis Tool, be sure to allowlist the Databricks account console and relevant Databricks workspace endpoints.
 
 ---
 

--- a/aws/tf/main.tf
+++ b/aws/tf/main.tf
@@ -5,15 +5,15 @@ module "sra" {
     aws            = aws
   }
 
-  databricks_account_id     = var.databricks_account_id
-  client_id                 = var.client_id
-  client_secret             = var.client_secret
-  aws_account_id            = var.aws_account_id
-  region                    = var.region
-  region_name               = var.region_name[var.region]
-  region_bucket_name        = var.region_bucket_name[var.region]
-  admin_user                = var.admin_user
-  resource_prefix           = var.resource_prefix
+  databricks_account_id = var.databricks_account_id
+  client_id             = var.client_id
+  client_secret         = var.client_secret
+  aws_account_id        = var.aws_account_id
+  region                = var.region
+  region_name           = var.region_name[var.region]
+  region_bucket_name    = var.region_bucket_name[var.region]
+  admin_user            = var.admin_user
+  resource_prefix       = var.resource_prefix
 
   # REQUIRED:
   network_configuration     = "isolated" # Network (custom or isolated), see README.md for more information.

--- a/aws/tf/modules/sra/cmk.tf
+++ b/aws/tf/modules/sra/cmk.tf
@@ -1,4 +1,4 @@
-# EXPLANATION: The customer-managed keys for workspace and managed storage
+# EXPLANATION: The customer-managed keys for workspace and managed services
 
 locals {
   cmk_admin_value = var.cmk_admin_arn == null ? "arn:aws:iam::${var.aws_account_id}:root" : var.cmk_admin_arn
@@ -74,12 +74,12 @@ resource "aws_kms_alias" "workspace_storage_key_alias" {
   target_key_id = aws_kms_key.workspace_storage.id
 }
 
-# CMK for Managed Storage
+# CMK for Managed Services
 
-resource "aws_kms_key" "managed_storage" {
-  description = "KMS key for managed storage"
+resource "aws_kms_key" "managed_services" {
+  description = "KMS key for managed services"
   policy = jsonencode({ Version : "2012-10-17",
-    "Id" : "key-policy-managed-storage",
+    "Id" : "key-policy-managed-services",
     Statement : [
       {
         "Sid" : "Enable IAM User Permissions",
@@ -113,11 +113,11 @@ resource "aws_kms_key" "managed_storage" {
 
   tags = {
     Project = var.resource_prefix
-    Name    = "${var.resource_prefix}-managed-storage-key"
+    Name    = "${var.resource_prefix}-managed-services-key"
   }
 }
 
-resource "aws_kms_alias" "managed_storage_key_alias" {
-  name          = "alias/${var.resource_prefix}-managed-storage-key"
-  target_key_id = aws_kms_key.managed_storage.key_id
+resource "aws_kms_alias" "managed_services_key_alias" {
+  name          = "alias/${var.resource_prefix}-managed-services-key"
+  target_key_id = aws_kms_key.managed_services.key_id
 }

--- a/aws/tf/modules/sra/credential.tf
+++ b/aws/tf/modules/sra/credential.tf
@@ -21,15 +21,145 @@ resource "aws_iam_role_policy" "cross_account" {
     "Version" : "2012-10-17",
     "Statement" : [
       {
-        "Sid" : "NonResourceBasedPermissions",
+        "Sid" : "CreateEC2ResourcesWithRequestTag",
         "Effect" : "Allow",
         "Action" : [
+          "ec2:CreateFleet",
+          "ec2:CreateLaunchTemplate",
+          "ec2:CreateLaunchTemplateVersion",
+          "ec2:CreateVolume",
+          "ec2:RequestSpotInstances",
+          "ec2:RunInstances"
+        ],
+        "Resource" : [
+          "arn:aws:ec2:${var.region}:${var.aws_account_id}:volume/*",
+          "arn:aws:ec2:${var.region}:${var.aws_account_id}:instance/*",
+          "arn:aws:ec2:${var.region}:${var.aws_account_id}:fleet/*",
+          "arn:aws:ec2:${var.region}:${var.aws_account_id}:launch-template/*",
+          "arn:aws:ec2:${var.region}:${var.aws_account_id}:network-interface/*"
+        ],
+        "Condition" : {
+          "StringEquals" : {
+            "aws:RequestTag/Vendor" : "Databricks"
+          }
+        }
+      },
+      {
+        "Sid" : "AllowDatabricksTagOnCreate",
+        "Effect" : "Allow",
+        "Action" : [
+          "ec2:CreateTags"
+        ],
+        "Resource" : [
+          "arn:aws:ec2:${var.region}:${var.aws_account_id}:volume/*",
+          "arn:aws:ec2:${var.region}:${var.aws_account_id}:instance/*",
+          "arn:aws:ec2:${var.region}:${var.aws_account_id}:launch-template/*",
+          "arn:aws:ec2:${var.region}:${var.aws_account_id}:fleet/*",
+          "arn:aws:ec2:${var.region}:${var.aws_account_id}:network-interface/*"
+        ],
+        "Condition" : {
+          "StringEquals" : {
+            "ec2:CreateAction" : [
+              "CreateFleet",
+              "CreateLaunchTemplate",
+              "CreateVolume",
+              "RequestSpotInstances",
+              "RunInstances"
+            ],
+            "aws:RequestTag/Vendor" : "Databricks"
+          }
+        }
+      },
+      {
+        "Sid" : "ModifyEC2ResourcesByResourceTags",
+        "Effect" : "Allow",
+        "Action" : [
+          "ec2:AssignPrivateIpAddresses",
+          "ec2:AssociateIamInstanceProfile",
+          "ec2:AttachVolume",
           "ec2:CancelSpotInstanceRequests",
+          "ec2:CreateLaunchTemplateVersion",
+          "ec2:DetachVolume",
+          "ec2:DisassociateIamInstanceProfile",
+          "ec2:ModifyFleet",
+          "ec2:ModifyLaunchTemplate",
+          "ec2:RequestSpotInstances",
+          "ec2:CreateFleet",
+          "ec2:CreateLaunchTemplate",
+          "ec2:CreateVolume",
+          "ec2:RunInstances"
+        ],
+        "Resource" : [
+          "arn:aws:ec2:${var.region}:${var.aws_account_id}:instance/*",
+          "arn:aws:ec2:${var.region}:${var.aws_account_id}:volume/*",
+          "arn:aws:ec2:${var.region}:${var.aws_account_id}:network-interface/*",
+          "arn:aws:ec2:${var.region}:${var.aws_account_id}:launch-template/*",
+          "arn:aws:ec2:${var.region}:${var.aws_account_id}:fleet/*",
+          "arn:aws:ec2:${var.region}:${var.aws_account_id}:spot-instance-request/*"
+        ],
+        "Condition" : {
+          "StringEquals" : {
+            "ec2:ResourceTag/Vendor" : "Databricks"
+          }
+        }
+      },
+      {
+        "Sid" : "GetEC2LaunchTemplateDataByTag",
+        "Effect" : "Allow",
+        "Action" : [
+          "ec2:GetLaunchTemplateData"
+        ],
+        "Resource" : [
+          "arn:aws:ec2:${var.region}:${var.aws_account_id}:volume/*",
+          "arn:aws:ec2:${var.region}:${var.aws_account_id}:instance/*",
+          "arn:aws:ec2:${var.region}:${var.aws_account_id}:fleet/*"
+        ],
+        "Condition" : {
+          "StringEquals" : {
+            "ec2:ResourceTag/Vendor" : "Databricks"
+          }
+        }
+      },
+      {
+        "Sid" : "DeleteEC2ResourcesByTag",
+        "Effect" : "Allow",
+        "Action" : [
+          "ec2:DeleteFleets",
+          "ec2:DeleteLaunchTemplate",
+          "ec2:DeleteLaunchTemplateVersions",
+          "ec2:DeleteTags",
+          "ec2:DeleteVolume",
+          "ec2:TerminateInstances"
+        ],
+        "Resource" : [
+          "arn:aws:ec2:${var.region}:${var.aws_account_id}:instance/*",
+          "arn:aws:ec2:${var.region}:${var.aws_account_id}:volume/*",
+          "arn:aws:ec2:${var.region}:${var.aws_account_id}:network-interface/*",
+          "arn:aws:ec2:${var.region}:${var.aws_account_id}:launch-template/*",
+          "arn:aws:ec2:${var.region}:${var.aws_account_id}:fleet/*",
+          "arn:aws:ec2:${var.region}:${var.aws_account_id}:spot-instance-request/*"
+        ],
+        "Condition" : {
+          "StringEquals" : {
+            "ec2:ResourceTag/Vendor" : "Databricks"
+          }
+        }
+      },
+      {
+        "Sid" : "DescribeEC2Resources",
+        "Effect" : "Allow",
+        "Action" : [
           "ec2:DescribeAvailabilityZones",
+          "ec2:DescribeFleetHistory",
+          "ec2:DescribeFleetInstances",
+          "ec2:DescribeVpcAttribute",
+          "ec2:DescribeFleets",
           "ec2:DescribeIamInstanceProfileAssociations",
           "ec2:DescribeInstanceStatus",
           "ec2:DescribeInstances",
           "ec2:DescribeInternetGateways",
+          "ec2:DescribeLaunchTemplates",
+          "ec2:DescribeLaunchTemplateVersions",
           "ec2:DescribeNatGateways",
           "ec2:DescribeNetworkAcls",
           "ec2:DescribePrefixLists",
@@ -40,50 +170,26 @@ resource "aws_iam_role_policy" "cross_account" {
           "ec2:DescribeSpotPriceHistory",
           "ec2:DescribeSubnets",
           "ec2:DescribeVolumes",
-          "ec2:DescribeVpcAttribute",
           "ec2:DescribeVpcs",
-          "ec2:CreateTags",
-          "ec2:DeleteTags",
-          "ec2:RequestSpotInstances"
-        ],
-        "Resource" : [
-          "*"
-        ]
-      },
-      {
-        "Sid" : "FleetPermissions",
-        "Effect" : "Allow",
-        "Action" : [
-          "ec2:DescribeFleetHistory",
-          "ec2:ModifyFleet",
-          "ec2:DeleteFleets",
-          "ec2:DescribeFleetInstances",
-          "ec2:DescribeFleets",
-          "ec2:CreateFleet",
-          "ec2:DeleteLaunchTemplate",
-          "ec2:GetLaunchTemplateData",
-          "ec2:CreateLaunchTemplate",
-          "ec2:DescribeLaunchTemplates",
-          "ec2:DescribeLaunchTemplateVersions",
-          "ec2:ModifyLaunchTemplate",
-          "ec2:DeleteLaunchTemplateVersions",
-          "ec2:CreateLaunchTemplateVersion",
-          "ec2:AssignPrivateIpAddresses",
           "ec2:GetSpotPlacementScores"
         ],
-        "Resource" : [
-          "*"
-        ]
+        "Resource" : "*"
       },
       {
-        "Sid" : "InstancePoolsSupport",
+        "Sid" : "AllowEC2TaggingOnDatabricksResources",
         "Effect" : "Allow",
         "Action" : [
-          "ec2:AssociateIamInstanceProfile",
-          "ec2:DisassociateIamInstanceProfile",
-          "ec2:ReplaceIamInstanceProfileAssociation"
+          "ec2:CreateTags",
+          "ec2:DeleteTags"
         ],
-        "Resource" : "arn:aws:ec2:${var.region}:${var.aws_account_id}:instance/*",
+        "Resource" : [
+          "arn:aws:ec2:${var.region}:${var.aws_account_id}:instance/*",
+          "arn:aws:ec2:${var.region}:${var.aws_account_id}:volume/*",
+          "arn:aws:ec2:${var.region}:${var.aws_account_id}:network-interface/*",
+          "arn:aws:ec2:${var.region}:${var.aws_account_id}:launch-template/*",
+          "arn:aws:ec2:${var.region}:${var.aws_account_id}:fleet/*",
+          "arn:aws:ec2:${var.region}:${var.aws_account_id}:spot-instance-request/*"
+        ],
         "Condition" : {
           "StringEquals" : {
             "ec2:ResourceTag/Vendor" : "Databricks"
@@ -91,52 +197,14 @@ resource "aws_iam_role_policy" "cross_account" {
         }
       },
       {
-        "Sid" : "AllowEc2RunInstancePerTag",
-        "Effect" : "Allow",
-        "Action" : "ec2:RunInstances",
-        "Resource" : [
-          "arn:aws:ec2:${var.region}:${var.aws_account_id}:volume/*",
-          "arn:aws:ec2:${var.region}:${var.aws_account_id}:instance/*"
-        ],
-        "Condition" : {
-          "StringEquals" : {
-            "aws:RequestTag/Vendor" : "Databricks"
-        } }
-      },
-      {
-        "Sid" : "AllowEc2RunInstancePerVPCid",
-        "Effect" : "Allow",
-        "Action" : "ec2:RunInstances",
-        "Resource" : [
-          "arn:aws:ec2:${var.region}:${var.aws_account_id}:network-interface/*",
-          "arn:aws:ec2:${var.region}:${var.aws_account_id}:subnet/*",
-          "arn:aws:ec2:${var.region}:${var.aws_account_id}:security-group/*"
-        ],
-        "Condition" : {
-          "StringEquals" : {
-            "ec2:vpc" : "arn:aws:ec2:${var.region}:${var.aws_account_id}:vpc/${var.custom_vpc_id != null ? var.custom_vpc_id : module.vpc[0].vpc_id}"
-          }
-        }
-      },
-      {
-        "Sid" : "AllowEc2RunInstanceOtherResources",
-        "Effect" : "Allow",
-        "Action" : "ec2:RunInstances",
-        "NotResource" : [
-          "arn:aws:ec2:${var.region}:${var.aws_account_id}:network-interface/*",
-          "arn:aws:ec2:${var.region}:${var.aws_account_id}:subnet/*",
-          "arn:aws:ec2:${var.region}:${var.aws_account_id}:security-group/*",
-          "arn:aws:ec2:${var.region}:${var.aws_account_id}:volume/*",
-          "arn:aws:ec2:${var.region}:${var.aws_account_id}:instance/*"
-        ]
-      },
-      {
-        "Sid" : "DatabricksSuppliedImages",
+        "Sid" : "RestrictAMIUsageToDatabricksDeny",
         "Effect" : "Deny",
-        "Action" : "ec2:RunInstances",
-        "Resource" : [
-          "arn:aws:ec2:*:*:image/*"
+        "Action" : [
+          "ec2:RunInstances",
+          "ec2:CreateFleet",
+          "ec2:RequestSpotInstances"
         ],
+        "Resource" : "arn:aws:ec2:*:*:image/*",
         "Condition" : {
           "StringNotEquals" : {
             "ec2:Owner" : "601306020600"
@@ -144,72 +212,39 @@ resource "aws_iam_role_policy" "cross_account" {
         }
       },
       {
-        "Sid" : "EC2TerminateInstancesTag",
+        "Sid" : "RestrictAMIUsageToDatabricksAllow",
         "Effect" : "Allow",
         "Action" : [
-          "ec2:TerminateInstances"
+          "ec2:RunInstances",
+          "ec2:CreateFleet",
+          "ec2:RequestSpotInstances"
         ],
-        "Resource" : [
-          "arn:aws:ec2:${var.region}:${var.aws_account_id}:instance/*"
-        ],
+        "Resource" : "arn:aws:ec2:*:*:image/*",
         "Condition" : {
           "StringEquals" : {
-            "ec2:ResourceTag/Vendor" : "Databricks"
+            "ec2:Owner" : "601306020600"
           }
         }
       },
       {
-        "Sid" : "EC2AttachDetachVolumeTag",
+        "Sid" : "AllowRunInstancesWithScopedResources",
         "Effect" : "Allow",
-        "Action" : [
-          "ec2:AttachVolume",
-          "ec2:DetachVolume"
-        ],
+        "Action" : "ec2:RunInstances",
         "Resource" : [
-          "arn:aws:ec2:${var.region}:${var.aws_account_id}:instance/*",
-          "arn:aws:ec2:${var.region}:${var.aws_account_id}:volume/*"
+          "arn:aws:ec2:${var.region}:${var.aws_account_id}:subnet/*",
+          "arn:aws:ec2:${var.region}:${var.aws_account_id}:security-group/*"
         ],
         "Condition" : {
-          "StringEquals" : {
-            "ec2:ResourceTag/Vendor" : "Databricks"
+          "StringEqualsIfExists" : {
+            "ec2:vpc" : "arn:aws:ec2:${var.region}:${var.aws_account_id}:vpc/${var.custom_vpc_id != null ? var.custom_vpc_id : module.vpc[0].vpc_id}"
           }
         }
       },
       {
-        "Sid" : "EC2CreateVolumeByTag",
+        "Sid" : "IAMRoleForEC2Spot",
         "Effect" : "Allow",
         "Action" : [
-          "ec2:CreateVolume"
-        ],
-        "Resource" : [
-          "arn:aws:ec2:${var.region}:${var.aws_account_id}:volume/*"
-        ],
-        "Condition" : {
-          "StringEquals" : {
-            "aws:RequestTag/Vendor" : "Databricks"
-          }
-        }
-      },
-      {
-        "Sid" : "EC2DeleteVolumeByTag",
-        "Effect" : "Allow",
-        "Action" : [
-          "ec2:DeleteVolume"
-        ],
-        "Resource" : [
-          "arn:aws:ec2:${var.region}:${var.aws_account_id}:volume/*"
-        ],
-        "Condition" : {
-          "StringEquals" : {
-            "ec2:ResourceTag/Vendor" : "Databricks"
-          }
-        }
-      },
-      {
-        "Effect" : "Allow",
-        "Action" : [
-          "iam:CreateServiceLinkedRole",
-          "iam:PutRolePolicy"
+          "iam:CreateServiceLinkedRole"
         ],
         "Resource" : "arn:aws:iam::*:role/aws-service-role/spot.amazonaws.com/AWSServiceRoleForEC2Spot",
         "Condition" : {

--- a/aws/tf/modules/sra/databricks_account.tf
+++ b/aws/tf/modules/sra/databricks_account.tf
@@ -41,9 +41,9 @@ module "databricks_mws_workspace" {
   region                      = var.region
   backend_rest                = var.custom_workspace_vpce_id != null ? var.custom_workspace_vpce_id : aws_vpc_endpoint.backend_rest[0].id
   backend_relay               = var.custom_relay_vpce_id != null ? var.custom_relay_vpce_id : aws_vpc_endpoint.backend_relay[0].id
-  managed_storage_key         = aws_kms_key.managed_storage.arn
+  managed_services_key        = aws_kms_key.managed_services.arn
   workspace_storage_key       = aws_kms_key.workspace_storage.arn
-  managed_storage_key_alias   = aws_kms_alias.managed_storage_key_alias.name
+  managed_services_key_alias  = aws_kms_alias.managed_services_key_alias.name
   workspace_storage_key_alias = aws_kms_alias.workspace_storage_key_alias.name
   deployment_name             = var.deployment_name
 }
@@ -62,13 +62,12 @@ module "user_assignment" {
 
 # Audit log delivery
 module "log_delivery" {
-  count = var.audit_log_delivery_exists ? 0 : 1
+  count  = var.audit_log_delivery_exists ? 0 : 1
   source = "./databricks_account/audit_log_delivery"
   providers = {
     databricks = databricks.mws
   }
 
-  audit_log_delivery_exists = var.audit_log_delivery_exists
-  databricks_account_id     = var.databricks_account_id
-  resource_prefix           = var.resource_prefix
+  databricks_account_id = var.databricks_account_id
+  resource_prefix       = var.resource_prefix
 }

--- a/aws/tf/modules/sra/databricks_account/audit_log_delivery/variables.tf
+++ b/aws/tf/modules/sra/databricks_account/audit_log_delivery/variables.tf
@@ -1,8 +1,3 @@
-variable "audit_log_delivery_exists" {
-  description = "If audit log delivery is already configured"
-  type        = bool
-}
-
 variable "databricks_account_id" {
   description = "ID of the Databricks account."
   type        = string

--- a/aws/tf/modules/sra/databricks_account/uc_init/main.tf
+++ b/aws/tf/modules/sra/databricks_account/uc_init/main.tf
@@ -8,7 +8,7 @@ data "databricks_metastore" "this" {
 
 resource "databricks_metastore" "this" {
   count         = var.metastore_exists ? 0 : 1
-  name          = "${var.resource_prefix}-${var.region}-unity-catalog"
+  name          = "${var.region}-unity-catalog"
   region        = var.region
   force_destroy = true
 }

--- a/aws/tf/modules/sra/databricks_account/workspace/main.tf
+++ b/aws/tf/modules/sra/databricks_account/workspace/main.tf
@@ -54,12 +54,12 @@ resource "databricks_mws_networks" "this" {
   }
 }
 
-# Managed Key Configuration
-resource "databricks_mws_customer_managed_keys" "managed_storage" {
+# Managed Services Key Configuration
+resource "databricks_mws_customer_managed_keys" "managed_services" {
   account_id = var.databricks_account_id
   aws_key_info {
-    key_arn   = var.managed_storage_key
-    key_alias = var.managed_storage_key_alias
+    key_arn   = var.managed_services_key
+    key_alias = var.managed_services_key_alias
   }
   use_cases = ["MANAGED_SERVICES"]
 }
@@ -92,7 +92,7 @@ resource "databricks_mws_workspaces" "workspace" {
   storage_configuration_id                 = databricks_mws_storage_configurations.this.storage_configuration_id
   network_id                               = databricks_mws_networks.this.network_id
   private_access_settings_id               = databricks_mws_private_access_settings.pas.private_access_settings_id
-  managed_services_customer_managed_key_id = databricks_mws_customer_managed_keys.managed_storage.customer_managed_key_id
+  managed_services_customer_managed_key_id = databricks_mws_customer_managed_keys.managed_services.customer_managed_key_id
   storage_customer_managed_key_id          = databricks_mws_customer_managed_keys.workspace_storage.customer_managed_key_id
   pricing_tier                             = "ENTERPRISE"
 

--- a/aws/tf/modules/sra/databricks_account/workspace/variables.tf
+++ b/aws/tf/modules/sra/databricks_account/workspace/variables.tf
@@ -29,13 +29,13 @@ variable "deployment_name" {
   nullable    = true
 }
 
-variable "managed_storage_key" {
-  description = "CMK for managed storage."
+variable "managed_services_key" {
+  description = "CMK for managed services."
   type        = string
 }
 
-variable "managed_storage_key_alias" {
-  description = "CMK for managed storage alias."
+variable "managed_services_key_alias" {
+  description = "CMK for managed services alias."
   type        = string
 }
 

--- a/aws/tf/modules/sra/databricks_workspace/classic_cluster/main.tf
+++ b/aws/tf/modules/sra/databricks_workspace/classic_cluster/main.tf
@@ -19,22 +19,15 @@ resource "databricks_cluster" "example" {
   }
 
   aws_attributes {
-    availability           = "ON_DEMAND"
-    ebs_volume_count       = 1
-    ebs_volume_size        = 32  # Size in GB, adjust as needed
-    ebs_volume_type        = "GENERAL_PURPOSE_SSD"
+    availability     = "ON_DEMAND"
+    ebs_volume_count = 1
+    ebs_volume_size  = 32 # Size in GB, adjust as needed
+    ebs_volume_type  = "GENERAL_PURPOSE_SSD"
   }
 
-  # Derby Metastore configs
+  # Unity Catalog only configuration
   spark_conf = {
-    "spark.hadoop.datanucleus.autoCreateTables" : "true",
-    "spark.hadoop.datanucleus.autoCreateSchema" : "true",
-    "spark.hadoop.javax.jdo.option.ConnectionDriverName" : "org.apache.derby.jdbc.EmbeddedDriver",
-    "spark.hadoop.javax.jdo.option.ConnectionPassword" : "hivepass",
-    "spark.hadoop.javax.jdo.option.ConnectionURL" : "jdbc:derby:memory:myInMemDB;create=true",
-    "spark.sql.catalogImplementation" : "hive",
-    "spark.hadoop.javax.jdo.option.ConnectionUserName" : "hiveuser",
-    "spark.hadoop.datanucleus.fixedDatastore" : "false"
+    "spark.databricks.unityCatalogOnlyMode" : "true"
   }
 
   # Custom Tags

--- a/aws/tf/modules/sra/security_analysis_tool.tf
+++ b/aws/tf/modules/sra/security_analysis_tool.tf
@@ -7,7 +7,7 @@ module "security_analysis_tool" {
   providers = {
     databricks = databricks.created_workspace
   }
-  
+
   account_console_id   = var.databricks_account_id
   client_id            = var.client_id
   client_secret        = var.client_secret

--- a/aws/tf/provider.tf
+++ b/aws/tf/provider.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     databricks = {
       source  = "databricks/databricks"
-      version = "1.54.0"
+      version = "1.70.0"
     }
     aws = {
       source  = "hashicorp/aws"


### PR DESCRIPTION
In this PR:

**Addressed the following issues:**
- #143. Upgrade provider from 1.54.0 -> 1.70.0
- #141. Removed Apache Derby configuration in favor of native Unity Catalog only mode - [documentation](https://docs.databricks.com/aws/en/data-governance/unity-catalog/disable-hms).
- #139. Updated all references from data plane to classic compute plane, updated all references from _managed_storage_ to _managed_services_.
- #152. Remove not needed audit log variable.

**New additions:**
- Updated Cross Account Role Policy. This role policy is further scoped-down from public documentation.
