### PR TITLE
Restricting AWS Outbound Security Group Rules

### DIFF
--- a/aws/tf/datasources.tf
+++ b/aws/tf/datasources.tf
@@ -1,3 +1,7 @@
 data "aws_availability_zones" "available" {
   state = "available"
 }
+
+data "aws_prefix_list" "s3" {
+  name = "com.amazonaws.${var.region}.s3"
+}

--- a/aws/tf/network.tf
+++ b/aws/tf/network.tf
@@ -64,8 +64,20 @@ resource "aws_security_group" "sg" {
       from_port   = egress.value
       to_port     = egress.value
       protocol    = "tcp"
-      cidr_blocks = ["0.0.0.0/0"]
+      cidr_blocks = [var.vpc_cidr_range]
     }
+  }
+
+  dynamic "egress"{
+    for_each = var.network_configuration != "custom" ? [1] : []
+    content{
+      from_port         = 443
+      to_port           = 443
+      protocol          = "tcp"
+      prefix_list_ids   = [data.aws_prefix_list.s3.id]
+      description       = "S3 access via Gateway Endpoint"
+    }
+  
   }
 
   tags = {


### PR DESCRIPTION
Restricting AWS Outbound Security group rules to intra-VPC for required ports and the S3 Prefix List on Port 443. 
[GitHub Issue](https://github.com/databricks/terraform-databricks-sra/issues/179)