### PR TITLE
less restrictive provider versions

### DIFF
--- a/aws/tf/provider.tf
+++ b/aws/tf/provider.tf
@@ -2,11 +2,11 @@ terraform {
   required_providers {
     databricks = {
       source  = "databricks/databricks"
-      version = "1.84.0"
+      version = "~> 1.84"
     }
     aws = {
       source  = "hashicorp/aws"
-      version = "5.76.0"
+      version = ">= 5.76, <7.0"
     }
   }
   required_version = "~>1.3"


### PR DESCRIPTION
We use aws provider 6.0 in the same terraform we are calling this module from. For now, we have to clone this module internally and modify it to remove this restrictive AWS provider version. Allowing version 6.0 would be appreciated.

https://github.com/hashicorp/terraform-provider-aws/releases/tag/v6.0.0 lists 6.0 breaking changes that should be reviewed