### PR TITLE
fix(aws): Typo in cluster creation comment

### DIFF
--- a/aws/tf/main.tf
+++ b/aws/tf/main.tf
@@ -173,7 +173,7 @@ module "compliance_security_profile" {
   compliance_standards = var.compliance_standards
 }
 
-# Create Create Cluster
+# Create Cluster
 module "cluster_configuration" {
   source = "./modules/databricks_workspace/classic_cluster"
   providers = {
@@ -216,3 +216,4 @@ module "security_analysis_tool" {
 
   depends_on = [module.unity_catalog_catalog_creation]
 }
+


### PR DESCRIPTION
Before:
<img width="1482" height="488" alt="silicon-2026-01-05-101133" src="https://github.com/user-attachments/assets/27c16631-3958-4111-a0cc-0e94c4ce14d7" />

After:
<img width="1482" height="488" alt="silicon-2026-01-05-101119" src="https://github.com/user-attachments/assets/6e13490a-c141-4cfd-a668-6585982e47e8" />