### PR TITLE
refactor(gcp): workspace_deployment module

### DIFF
--- a/gcp/examples/byo_gcp_workspace_deployment/init.tf
+++ b/gcp/examples/byo_gcp_workspace_deployment/init.tf
@@ -1,5 +1,32 @@
+terraform {
+  # Remote state backend.
+  # Uncomment the `backend "gcs" {}` line below to store state in GCS instead
+  # of the local filesystem. Provide bucket and prefix at init time:
+  #   terraform init \
+  #     -backend-config="bucket=my-tfstate-bucket" \
+  #     -backend-config="prefix=databricks/byo_gcp_workspace_deployment"
+  # If left commented, Terraform uses the default local backend
+  # (terraform.tfstate in this directory).
+  # backend "gcs" {}
+
+  required_providers {
+    databricks = {
+      source  = "databricks/databricks"
+      version = ">=1.113.0"
+    }
+    google = {
+      source  = "hashicorp/google"
+      version = ">=5.43.1"
+    }
+  }
+}
+
 provider "google" {
   project = var.project
 }
 
-# data "google_client_config" "current" {}
+provider "databricks" {
+  alias      = "accounts"
+  host       = var.account_console_url
+  account_id = var.databricks_account_id
+}

--- a/gcp/examples/byo_gcp_workspace_deployment/main.tf
+++ b/gcp/examples/byo_gcp_workspace_deployment/main.tf
@@ -1,49 +1,50 @@
 
 module "customer_managed_vpc" {
-  source                      = "../../modules/workspace_deployment/"
-  google_project = var.google_project #Google Cloud project id (GCP)
-  google_region = var.google_region  #Google Cloud region (GCP)
-  databricks_account_id = var.databricks_account_id #Databricks account id (Databricks)
+  source                            = "../../modules/workspace_deployment/"
+  google_project                    = var.google_project        #Google Cloud project id (GCP)
+  google_region                     = var.google_region         #Google Cloud region (GCP)
+  databricks_account_id             = var.databricks_account_id #Databricks account id (Databricks)
   databricks_google_service_account = var.databricks_google_service_account
-  workspace_name = var.workspace_name #Name of the Databricks workspace to be created (Databricks)
-  account_console_url = var.account_console_url #Databricks Account console url (Databricks)
+  workspace_name                    = var.workspace_name      #Name of the Databricks workspace to be created (Databricks)
+  account_console_url               = var.account_console_url #Databricks Account console url (Databricks)
 
-    
-  
+
+
   #IP ACCESS LIST
-  ip_addresses=var.ip_addresses #Databricks Workspace IP Access List (Databricks)
- 
+  ip_addresses = var.ip_addresses #Databricks Workspace IP Access List (Databricks)
+
   #VPC RESOURCES
-  use_existing_vpc = var.use_existing_vpc #Flag to use existing vpc or create a new one
-  existing_vpc_name = var.existing_vpc_name
+  use_existing_vpc     = var.use_existing_vpc #Flag to use existing vpc or create a new one
+  existing_vpc_name    = var.existing_vpc_name
   existing_subnet_name = var.existing_subnet_name
 
   #PSC RESOURCES
   google_pe_subnet = var.google_pe_subnet #Name of the subnet to be used for the PSC endpoints (GCP)
 
-  use_psc = var.use_psc #Flag to enable Private Service Connect (PSC) for the workspace
-  use_existing_pas = var.use_existing_pas #Flag to use existing private access settings or create a new one
-  existing_pas_id = var.existing_pas_id #Required if use_existing_pas is true
-  use_existing_PSC_EP = var.use_existing_psc_eps #Flag to use existing PSC endpoints or create a new ones
+  use_psc                         = var.use_psc                         #Flag to enable Private Service Connect (PSC) for the workspace
+  use_existing_pas                = var.use_existing_pas                #Flag to use existing private access settings or create a new one
+  existing_pas_id                 = var.existing_pas_id                 #Required if use_existing_pas is true
+  use_existing_PSC_EP             = var.use_existing_psc_eps            #Flag to use existing PSC endpoints or create a new ones
   use_existing_databricks_vpc_eps = var.use_existing_databricks_vpc_eps #Flag to use existing Databricks VPC Endpoints for PSC or create a new ones
 
-  workspace_service_attachment = var.workspace_service_attachment #Workspace service attachment. Regional values - https://docs.databricks.com/gcp/en/resources/ip-domain-region#private-service-connect-psc-attachment-uris-and-project-numbers
-  workspace_pe = var.workspace_pe #Name of the PSC endpoint (found in GCP console) used for the workspace communication (GCP)
-  workspace_pe_ip_name = var.workspace_pe_ip_name #Workspace private endpoint IP name if not using an existing one (GCP)
+  workspace_service_attachment         = var.workspace_service_attachment         #Workspace service attachment. Regional values - https://docs.databricks.com/gcp/en/resources/ip-domain-region#private-service-connect-psc-attachment-uris-and-project-numbers
+  workspace_pe                         = var.workspace_pe                         #Name of the PSC endpoint (found in GCP console) used for the workspace communication (GCP)
+  workspace_pe_ip_name                 = var.workspace_pe_ip_name                 #Workspace private endpoint IP name if not using an existing one (GCP)
   existing_databricks_vpc_ep_workspace = var.existing_databricks_vpc_ep_workspace #Required if use_existing_databricks_vpc_eps is true. 
-  existing_databricks_vpc_ep_relay = var.existing_databricks_vpc_ep_relay #Required if use_existing_databricks_vpc_eps is true.
+  existing_databricks_vpc_ep_relay     = var.existing_databricks_vpc_ep_relay     #Required if use_existing_databricks_vpc_eps is true.
 
   relay_service_attachment = var.relay_service_attachment #Relay service attachment. Regional values - https://docs.databricks.com/gcp/en/resources/ip-domain-region#private-service-connect-psc-attachment-uris-and-project-numbers
-  relay_pe =  var.relay_pe #Name of the PSC endpoint (found in GCP console) used for the relay communication (GCP)
-  relay_pe_ip_name = var.relay_pe_ip_name #Relay private endpoint IP name if not using an existing one (GCP)
-  
-  #CMEK RESOURCES
-  use_existing_cmek = var.use_existing_cmek #Flag to use existing Cloud KMS Key or create a new one
-  key_name = var.key_name #Name of the key to be created if not using an existing one (GCP)
-  keyring_name = var.keyring_name #Name of the keyring to be created if not using an existing one (GCP)
-  cmek_resource_id = var.cmek_resource_id #Resource ID for the existing Cloud KMS Key (GCP)
+  relay_pe                 = var.relay_pe                 #Name of the PSC endpoint (found in GCP console) used for the relay communication (GCP)
+  relay_pe_ip_name         = var.relay_pe_ip_name         #Relay private endpoint IP name if not using an existing one (GCP)
 
-    # Flags
+  #CMEK RESOURCES
+  use_cmek          = var.use_cmek          #Master flag to enable CMEK
+  use_existing_cmek = var.use_existing_cmek #Flag to use existing Cloud KMS Key or create a new one
+  key_name          = var.key_name          #Name of the key to be created if not using an existing one (GCP)
+  keyring_name      = var.keyring_name      #Name of the keyring to be created if not using an existing one (GCP)
+  cmek_resource_id  = var.cmek_resource_id  #Resource ID for the existing Cloud KMS Key (GCP)
+
+  # Flags
   harden_network               = var.harden_network
-  provision_regional_metastore  = false 
+  provision_regional_metastore = false
 }

--- a/gcp/examples/byo_gcp_workspace_deployment/variables.tf
+++ b/gcp/examples/byo_gcp_workspace_deployment/variables.tf
@@ -34,6 +34,12 @@ variable "use_existing_vpc" {
 }
 variable "harden_network" {}
 
+variable "use_cmek" {
+  description = "Enable Customer-Managed Encryption Keys"
+  type        = bool
+  default     = false
+}
+
 variable "use_existing_cmek" {
   description = "Use existing cmek"
   type        = bool

--- a/gcp/examples/end-to-end provisionning/init.tf
+++ b/gcp/examples/end-to-end provisionning/init.tf
@@ -1,8 +1,18 @@
 terraform {
+  # Remote state backend.
+  # Uncomment the `backend "gcs" {}` line below to store state in GCS instead
+  # of the local filesystem. Provide bucket and prefix at init time:
+  #   terraform init \
+  #     -backend-config="bucket=my-tfstate-bucket" \
+  #     -backend-config="prefix=databricks/end-to-end"
+  # If left commented, Terraform uses the default local backend
+  # (terraform.tfstate in this directory).
+  # backend "gcs" {}
+
   required_providers {
     databricks = {
-      source = "databricks/databricks"
-      version = ">=1.51.0"
+      source  = "databricks/databricks"
+      version = ">=1.113.0"
     }
     google = {
       source  = "hashicorp/google"
@@ -11,15 +21,15 @@ terraform {
   }
 }
 
-# # Default provider for service account creation (uses your current auth)
+# Default Google provider (uses your current auth).
 provider "google" {
   project = var.google_project
   region  = var.google_region
 }
 
-# # Databricks provider for account operations
+# Databricks provider for account operations.
 provider "databricks" {
-  alias                  = "accounts"
-  host                   = "https://accounts.gcp.databricks.com"
-  account_id             = var.databricks_account_id
+  alias      = "accounts"
+  host       = "https://accounts.gcp.databricks.com"
+  account_id = var.databricks_account_id
 }

--- a/gcp/examples/end-to-end provisionning/main.tf
+++ b/gcp/examples/end-to-end provisionning/main.tf
@@ -1,45 +1,57 @@
 
 module "service_account" {
   source = "../../modules/service_account/"
-  # Bare Minimum Variables
-  project = var.google_project
-  sa_name = var.sa_name
-  create_service_account_key = true
-  delegate_from = var.delegate_from
-}
 
+  project                    = var.google_project
+  sa_name                    = var.sa_name
+  create_service_account_key = true
+  delegate_from              = var.delegate_from
+}
 
 module "make_sa_dbx_admin" {
   source = "../../modules/make_sa_dbx_admin/"
-  
-  databricks_account_id = var.databricks_account_id
-  new_admin_account = module.service_account.workspace_creator_email  # Use output from service_account module
-  dbx_existing_admin_account = data.google_client_openid_userinfo.me.email  # Use the current user's email as the existing admin account
+
+  databricks_account_id      = var.databricks_account_id
+  new_admin_account          = module.service_account.workspace_creator_email
+  dbx_existing_admin_account = data.google_client_openid_userinfo.me.email
 }
 
 module "customer_managed_vpc" {
-  source                      = "../../modules/workspace_deployment/"
-  
-  # Bare Minimum Variables
-  google_project               = var.google_project
-  google_region                = var.google_region
-  databricks_account_id        = var.databricks_account_id
-  databricks_google_service_account = module.service_account.workspace_creator_email  # Use output from service_account module
-  workspace_name               = var.workspace_name
-  databricks_google_service_account_key = module.service_account.workspace_creator_key  # Use output from service_account module
-  regional_metastore_id = var.regional_metastore_id
-  can_create_workspaces = module.service_account.workspace_creator_role_applied 
-  admin_user_email            = module.make_sa_dbx_admin.original_admin_account
-  cmek_resource_id           = var.cmek_resource_id
+  source = "../../modules/workspace_deployment/"
 
-  # Flags
-  use_existing_vpc             = false
-  use_existing_pas             = false
-  use_existing_PSC_EP          = false
-  use_existing_cmek            = true
-  use_psc                      = false
-  harden_network               = true
-  provision_regional_metastore  = false 
-  
+  google_project                        = var.google_project
+  google_region                         = var.google_region
+  databricks_account_id                 = var.databricks_account_id
+  databricks_google_service_account     = module.service_account.workspace_creator_email
+  workspace_name                        = var.workspace_name
+  databricks_google_service_account_key = module.service_account.workspace_creator_key
+  regional_metastore_id                 = var.regional_metastore_id
+  can_create_workspaces                 = module.service_account.workspace_creator_role_applied
+  admin_user_email                      = module.make_sa_dbx_admin.original_admin_account
+
+  # Networking — module creates VPC, subnet, PSC endpoints, firewalls
+  use_existing_vpc    = false
+  use_existing_pas    = false
+  use_existing_PSC_EP = false
+  use_psc             = true
+  harden_network      = true
+
+  # PSC service attachments and endpoint names
+  workspace_service_attachment = var.workspace_service_attachment
+  relay_service_attachment     = var.relay_service_attachment
+  workspace_pe                 = "sra-workspace-pe"
+  workspace_pe_ip_name         = "sra-workspace-pe-ip"
+  relay_pe                     = "sra-relay-pe"
+  relay_pe_ip_name             = "sra-relay-pe-ip"
+
+  # CMEK — module creates KMS keyring + key and registers with Databricks
+  use_cmek          = true
+  use_existing_cmek = false
+  keyring_name      = var.keyring_name
+  key_name          = var.key_name
+
+  # DNS — create a private zone for PSC resolution
+  create_dns_zone = true
+
+  provision_regional_metastore = false
 }
-

--- a/gcp/examples/end-to-end provisionning/outputs.tf
+++ b/gcp/examples/end-to-end provisionning/outputs.tf
@@ -2,6 +2,10 @@ output "service_account_email" {
   value = module.service_account.workspace_creator_email
 }
 
-output "databricks_host" {
-  value = module.customer_managed_vpc.databricks_host
+output "workspace_url" {
+  value = module.customer_managed_vpc.workspace_url
+}
+
+output "workspace_id" {
+  value = module.customer_managed_vpc.workspace_id
 }

--- a/gcp/examples/end-to-end provisionning/variables.tf
+++ b/gcp/examples/end-to-end provisionning/variables.tf
@@ -1,49 +1,65 @@
 
 ##### GENERAL VARIABLES #####
 variable "databricks_account_id" {
-    # Databricks account ID (found in the account console)
-} 
+  type        = string
+  description = "Databricks account ID (found in the account console)"
+}
+
 variable "sa_name" {
-    # Google service account for Databricks
-    default = "databricks-workspace-creator"
-} 
+  type        = string
+  default     = "databricks-workspace-creator"
+  description = "Google service account name for Databricks provisioning"
+}
+
 variable "google_project" {
-    # Name of the Google Cloud project
-} 
-variable "cmek_resource_id" {
-    # Customer-managed encryption key resource ID
-    default = ""
+  type        = string
+  description = "Google Cloud project ID"
 }
 
 variable "google_region" {
-    # Google Cloud region
-} 
-variable "workspace_name" { 
-    # Name you want to give to the Databricks workspace you are creating
-    default = "sra-deployed-ws"
+  type        = string
+  description = "Google Cloud region"
+}
+
+variable "workspace_name" {
+  type        = string
+  default     = "sra-deployed-ws"
+  description = "Name of the Databricks workspace to create"
 }
 
 variable "delegate_from" {
-    # List of users or service accounts to delegate permissions from
-    type    = list(string)
-    default = []
+  type        = list(string)
+  default     = []
+  description = "List of users or service accounts to delegate impersonation from (e.g. [\"user:you@example.com\"])"
+}
+
+##### PSC #####
+variable "workspace_service_attachment" {
+  type        = string
+  description = "PSC service attachment URI for the workspace endpoint (plproxy). See https://docs.databricks.com/gcp/en/resources/ip-domain-region"
 }
 
 variable "relay_service_attachment" {
-    # Relay service attachment. regional values - https://docs.gcp.databricks.com/resources/supported-regions.html#psc
-    default = "projects/prod-gcp-europe-west1/regions/europe-west1/serviceAttachments/ngrok-psc-endpoint"
-} 
-variable "workspace_service_attachment" { 
-    # Workspace service attachment. Regional values - https://docs.gcp.databricks.com/resources/supported-regions.html#psc
-    default = "projects/general-prod-europewest1-01/regions/europe-west1/serviceAttachments/plproxy-psc-endpoint-all-ports"
+  type        = string
+  description = "PSC service attachment URI for the SCC relay endpoint (ngrok). See https://docs.databricks.com/gcp/en/resources/ip-domain-region"
 }
 
+##### CMEK #####
+variable "keyring_name" {
+  type        = string
+  default     = "databricks-keyring"
+  description = "Name of the KMS keyring to create"
+}
 
+variable "key_name" {
+  type        = string
+  default     = "databricks-key"
+  description = "Name of the KMS crypto key to create"
+}
+
+##### METASTORE #####
 variable "regional_metastore_id" {
-    # ID of the regional Hive Metastore
-    default = "regional-metastore"
-}
-
-variable "provision_regional_metastore"{
-    default = false
+  type        = string
+  default     = ""
+  description = "ID of the regional Unity Catalog metastore to assign (leave empty to skip)"
 }

--- a/gcp/examples/service_account/main.tf
+++ b/gcp/examples/service_account/main.tf
@@ -1,7 +1,7 @@
 module "service_account" {
-  source                      = "../../modules/service_account/"
+  source        = "../../modules/service_account/"
   project       = var.project
-  prefix = var.prefix
+  prefix        = var.prefix
   delegate_from = var.delegate_from
 }
 

--- a/gcp/examples/simple_workspace_deployment/init.tf
+++ b/gcp/examples/simple_workspace_deployment/init.tf
@@ -1,5 +1,32 @@
+terraform {
+  # Remote state backend.
+  # Uncomment the `backend "gcs" {}` line below to store state in GCS instead
+  # of the local filesystem. Provide bucket and prefix at init time:
+  #   terraform init \
+  #     -backend-config="bucket=my-tfstate-bucket" \
+  #     -backend-config="prefix=databricks/simple_workspace_deployment"
+  # If left commented, Terraform uses the default local backend
+  # (terraform.tfstate in this directory).
+  # backend "gcs" {}
+
+  required_providers {
+    databricks = {
+      source  = "databricks/databricks"
+      version = ">=1.113.0"
+    }
+    google = {
+      source  = "hashicorp/google"
+      version = ">=5.43.1"
+    }
+  }
+}
+
 provider "google" {
   project = var.project
 }
 
-# data "google_client_config" "current" {}
+provider "databricks" {
+  alias      = "accounts"
+  host       = var.account_console_url
+  account_id = var.databricks_account_id
+}

--- a/gcp/examples/simple_workspace_deployment/main.tf
+++ b/gcp/examples/simple_workspace_deployment/main.tf
@@ -1,24 +1,25 @@
 
 module "customer_managed_vpc" {
-  source                      = "../../modules/workspace_deployment/"
-  google_project = var.google_project
-  google_region = var.google_region
-  databricks_account_id = var.databricks_account_id
+  source                            = "../../modules/workspace_deployment/"
+  google_project                    = var.google_project
+  google_region                     = var.google_region
+  databricks_account_id             = var.databricks_account_id
   databricks_google_service_account = var.databricks_google_service_account
-  use_existing_pas = var.use_existing_pas
-  workspace_name = var.workspace_name
+  use_existing_pas                  = var.use_existing_pas
+  workspace_name                    = var.workspace_name
 
-  workspace_pe = var.workspace_pe
-  relay_pe =  var.relay_pe
-  google_pe_subnet = var.google_pe_subnet 
-  relay_pe_ip_name = var.relay_pe_ip_name
-  workspace_pe_ip_name = var.workspace_pe_ip_name
-  relay_service_attachment = var.relay_service_attachment
+  workspace_pe                 = var.workspace_pe
+  relay_pe                     = var.relay_pe
+  google_pe_subnet             = var.google_pe_subnet
+  relay_pe_ip_name             = var.relay_pe_ip_name
+  workspace_pe_ip_name         = var.workspace_pe_ip_name
+  relay_service_attachment     = var.relay_service_attachment
   workspace_service_attachment = var.workspace_service_attachment
-  ip_addresses=var.ip_addresses
-  account_console_url = var.account_console_url
-  key_name = var.key_name
-  keyring_name = var.keyring_name
-  use_existing_cmek = var.use_existing_cmek
-  cmek_resource_id = var.cmek_resource_id
+  ip_addresses                 = var.ip_addresses
+  account_console_url          = var.account_console_url
+  key_name                     = var.key_name
+  keyring_name                 = var.keyring_name
+  use_cmek                     = var.use_cmek
+  use_existing_cmek            = var.use_existing_cmek
+  cmek_resource_id             = var.cmek_resource_id
 }

--- a/gcp/examples/simple_workspace_deployment/variables.tf
+++ b/gcp/examples/simple_workspace_deployment/variables.tf
@@ -17,6 +17,13 @@ variable "google_project" {}
 variable "databricks_account_id" {}
 variable "key_name" {}
 variable "keyring_name" {}
+
+variable "use_cmek" {
+  description = "Enable Customer-Managed Encryption Keys"
+  type        = bool
+  default     = false
+}
+
 variable "use_existing_cmek" {}
 variable "cmek_resource_id" {}
 

--- a/gcp/examples/unity_catalog/main.tf
+++ b/gcp/examples/unity_catalog/main.tf
@@ -1,14 +1,14 @@
 module "unity_catalog" {
-  source                      = "../../modules/unity_catalog/"
-  project       = var.project
-  databricks_workspace_ids = var.databricks_workspace_ids
-  databricks_workspace_url = var.databricks_workspace_url
-  location = var.location
-  resource_prefix = var.resource_prefix
-  databricks_google_service_account = var.databricks_google_service_account
-  databricks_account_id = var.databricks_account_id
-  account_console_url = var.account_console_url
-  data_access = var.data_access
-  existing_metastore_id=var.existing_metastore_id
+  source                                          = "../../modules/unity_catalog/"
+  project                                         = var.project
+  databricks_workspace_ids                        = var.databricks_workspace_ids
+  databricks_workspace_url                        = var.databricks_workspace_url
+  location                                        = var.location
+  resource_prefix                                 = var.resource_prefix
+  databricks_google_service_account               = var.databricks_google_service_account
+  databricks_account_id                           = var.databricks_account_id
+  account_console_url                             = var.account_console_url
+  data_access                                     = var.data_access
+  existing_metastore_id                           = var.existing_metastore_id
   databricks_workspace_ids_for_existing_metastore = var.databricks_workspace_ids_for_existing_metastore
 }

--- a/gcp/modules/make_sa_dbx_admin/main.tf
+++ b/gcp/modules/make_sa_dbx_admin/main.tf
@@ -1,10 +1,10 @@
 resource "databricks_user" "sa" {
-  provider = databricks
-  display_name         = "SA for Account Provisionning"
-  user_name = var.new_admin_account
+  provider     = databricks
+  display_name = "SA for Account Provisionning"
+  user_name    = var.new_admin_account
 }
 resource "databricks_user_role" "my_user_account_admin" {
   provider = databricks
-  user_id = databricks_user.sa.id
-  role    = "account_admin"
+  user_id  = databricks_user.sa.id
+  role     = "account_admin"
 }

--- a/gcp/modules/make_sa_dbx_admin/outputs.tf
+++ b/gcp/modules/make_sa_dbx_admin/outputs.tf
@@ -2,7 +2,7 @@
 output "granted_admin_account" {
   value       = databricks_user_role.my_user_account_admin.id
   description = "This email was added to the Databricks account as an admin user."
-  
+
 }
 
 output "original_admin_account" {

--- a/gcp/modules/make_sa_dbx_admin/providers.tf
+++ b/gcp/modules/make_sa_dbx_admin/providers.tf
@@ -3,18 +3,18 @@
 terraform {
   required_providers {
     databricks = {
-      source = "databricks/databricks"
+      source  = "databricks/databricks"
       version = ">=1.39.0"
 
     }
     google = {
-      source  = "hashicorp/google"
+      source = "hashicorp/google"
     }
 
   }
 }
 provider "databricks" {
-  host       = "https://accounts.gcp.databricks.com"
-  account_id = var.databricks_account_id
+  host                   = "https://accounts.gcp.databricks.com"
+  account_id             = var.databricks_account_id
   google_service_account = var.dbx_existing_admin_account
 }

--- a/gcp/modules/make_sa_dbx_admin/variables.tf
+++ b/gcp/modules/make_sa_dbx_admin/variables.tf
@@ -1,6 +1,6 @@
 variable "databricks_account_id" {}
 variable "new_admin_account" {}
 variable "dbx_existing_admin_account" {
-    description = "Existing Databricks SA or user. Allows either a user, e.g. \"name@example.com\" or a serviceAccount, e.g. \"sa1@project.iam.gserviceaccount.com\""
-    default     = ""
+  description = "Existing Databricks SA or user. Allows either a user, e.g. \"name@example.com\" or a serviceAccount, e.g. \"sa1@project.iam.gserviceaccount.com\""
+  default     = ""
 }

--- a/gcp/modules/service_account/data.tf
+++ b/gcp/modules/service_account/data.tf
@@ -13,7 +13,7 @@ data "google_client_openid_userinfo" "me" {}
 # }
 
 resource "random_string" "prefix" {
-    length  = 8
-    upper   = false
-    special = false
+  length  = 8
+  upper   = false
+  special = false
 }

--- a/gcp/modules/service_account/main.tf
+++ b/gcp/modules/service_account/main.tf
@@ -1,5 +1,5 @@
 resource "google_service_account" "workspace_creator" {
-  account_id   = "${var.sa_name}"
+  account_id   = var.sa_name
   display_name = "Service Account for Databricks Provisioning"
 }
 

--- a/gcp/modules/service_account/providers.tf
+++ b/gcp/modules/service_account/providers.tf
@@ -1,4 +1,4 @@
 provider "google" {
-    alias = "google-for-sa"
+  alias   = "google-for-sa"
   project = var.project
 }

--- a/gcp/modules/service_account/variables.tf
+++ b/gcp/modules/service_account/variables.tf
@@ -2,10 +2,10 @@ variable "sa_name" {
   description = "The name of the service account"
   type        = string
   default     = "databricks-workspace-creator"
-  }
+}
 
 variable "project" {
-  type    = string
+  type = string
 }
 
 variable "delegate_from" {

--- a/gcp/modules/unity_catalog/cluster.tf
+++ b/gcp/modules/unity_catalog/cluster.tf
@@ -29,7 +29,7 @@ locals {
 }
 
 resource "databricks_cluster_policy" "example" {
-  provider = databricks.workspace
+  provider   = databricks.workspace
   name       = "Example Cluster Policy"
   definition = jsonencode(local.default_policy)
 }

--- a/gcp/modules/unity_catalog/main.tf
+++ b/gcp/modules/unity_catalog/main.tf
@@ -24,85 +24,85 @@ resource "google_storage_bucket" "ext_bucket" {
 }
 
 resource "databricks_metastore" "this" {
-  provider = databricks.workspace
+  provider      = databricks.workspace
   name          = "unity-catalog-${var.resource_prefix}"
   storage_root  = "gs://${google_storage_bucket.unity_metastore.name}"
   force_destroy = true
 }
 
 resource "databricks_metastore_data_access" "first" {
-  provider = databricks.workspace
+  provider     = databricks.workspace
   metastore_id = databricks_metastore.this.id
   databricks_gcp_service_account {}
   name       = "the-keys"
   is_default = true
-  depends_on = [ databricks_metastore_assignment.this ]
+  depends_on = [databricks_metastore_assignment.this]
 }
 
 resource "google_storage_bucket_iam_member" "unity_sa_admin" {
-  depends_on = [ google_storage_bucket.unity_metastore ]
-  bucket = google_storage_bucket.unity_metastore.name
-  role   = "roles/storage.objectAdmin"
-  member = "serviceAccount:${databricks_metastore_data_access.first.databricks_gcp_service_account[0].email}"
+  depends_on = [google_storage_bucket.unity_metastore]
+  bucket     = google_storage_bucket.unity_metastore.name
+  role       = "roles/storage.objectAdmin"
+  member     = "serviceAccount:${databricks_metastore_data_access.first.databricks_gcp_service_account[0].email}"
 }
 
 resource "google_storage_bucket_iam_member" "unity_sa_reader" {
-  depends_on = [google_storage_bucket.unity_metastore ]
-  bucket = google_storage_bucket.unity_metastore.name
-  role   = "roles/storage.legacyBucketReader"
-  member = "serviceAccount:${databricks_metastore_data_access.first.databricks_gcp_service_account[0].email}"
+  depends_on = [google_storage_bucket.unity_metastore]
+  bucket     = google_storage_bucket.unity_metastore.name
+  role       = "roles/storage.legacyBucketReader"
+  member     = "serviceAccount:${databricks_metastore_data_access.first.databricks_gcp_service_account[0].email}"
 }
 
 
 
 resource "databricks_metastore_assignment" "this" {
-  depends_on = [databricks_metastore.this  ]
-  provider = databricks.workspace
-  count                = length(var.databricks_workspace_ids)
-  workspace_id         = var.databricks_workspace_ids[count.index]
-  metastore_id         = databricks_metastore.this.id
-  
+  depends_on   = [databricks_metastore.this]
+  provider     = databricks.workspace
+  count        = length(var.databricks_workspace_ids)
+  workspace_id = var.databricks_workspace_ids[count.index]
+  metastore_id = databricks_metastore.this.id
+
   default_catalog_name = "hive_metastore"
 }
 
 resource "databricks_metastore_assignment" "external" {
-  depends_on = [ databricks_metastore.this ]
-  provider = databricks.workspace
-  count                = length(var.databricks_workspace_ids_for_existing_metastore)
-  workspace_id         = var.databricks_workspace_ids_for_existing_metastore[count.index]
-  metastore_id         = var.existing_metastore_id
-  
+  depends_on   = [databricks_metastore.this]
+  provider     = databricks.workspace
+  count        = length(var.databricks_workspace_ids_for_existing_metastore)
+  workspace_id = var.databricks_workspace_ids_for_existing_metastore[count.index]
+  metastore_id = var.existing_metastore_id
+
   default_catalog_name = "hive_metastore"
 }
 
 //Storage credentials
 resource "databricks_storage_credential" "ext" {
-  depends_on = [ databricks_metastore_assignment.this ]
-  provider = databricks.workspace
-  name = "the-creds"
+  depends_on = [databricks_metastore_assignment.this]
+  provider   = databricks.workspace
+  name       = "the-creds"
   databricks_gcp_service_account {}
 }
 
 resource "google_storage_bucket_iam_member" "ext_admin" {
-  depends_on = [ google_storage_bucket.ext_bucket,databricks_storage_credential.ext ]
-  bucket = google_storage_bucket.ext_bucket.name
-  role   = "roles/storage.objectAdmin"
-  member = "serviceAccount:${databricks_storage_credential.ext.databricks_gcp_service_account[0].email}"
+  depends_on = [google_storage_bucket.ext_bucket, databricks_storage_credential.ext]
+  bucket     = google_storage_bucket.ext_bucket.name
+  role       = "roles/storage.objectAdmin"
+  member     = "serviceAccount:${databricks_storage_credential.ext.databricks_gcp_service_account[0].email}"
 }
 
 resource "google_storage_bucket_iam_member" "ext_reader" {
-  depends_on = [ google_storage_bucket.ext_bucket,databricks_storage_credential.ext ]
-  bucket = google_storage_bucket.ext_bucket.name
-  role   = "roles/storage.legacyBucketReader"
-  member = "serviceAccount:${databricks_storage_credential.ext.databricks_gcp_service_account[0].email}"
+  depends_on = [google_storage_bucket.ext_bucket, databricks_storage_credential.ext]
+  bucket     = google_storage_bucket.ext_bucket.name
+  role       = "roles/storage.legacyBucketReader"
+  member     = "serviceAccount:${databricks_storage_credential.ext.databricks_gcp_service_account[0].email}"
 }
 
 // External Location
 resource "databricks_external_location" "some" {
-  depends_on = [ databricks_storage_credential.ext,google_storage_bucket_iam_member.ext_admin,google_storage_bucket.ext_bucket,google_storage_bucket_iam_member.ext_reader ]
-  provider = databricks.workspace
-  name = "the-ext-location"
-  url  = "gs://${google_storage_bucket.ext_bucket.name}"
+  depends_on = [databricks_storage_credential.ext, google_storage_bucket_iam_member.ext_admin, google_storage_bucket.ext_bucket, google_storage_bucket_iam_member.ext_reader]
+  provider   = databricks.workspace
+  name       = "the-ext-location"
+  url        = "gs://${google_storage_bucket.ext_bucket.name}"
 
   credential_name = databricks_storage_credential.ext.id
   comment         = "Managed by TF"
@@ -110,8 +110,8 @@ resource "databricks_external_location" "some" {
 
 // External Location Grant
 resource "databricks_grants" "data_example" {
-  depends_on = [ databricks_external_location.some ]
-  provider = databricks.workspace
+  depends_on        = [databricks_external_location.some]
+  provider          = databricks.workspace
   external_location = databricks_external_location.some.id
   grant {
     principal  = var.data_access

--- a/gcp/modules/unity_catalog/provider.tf
+++ b/gcp/modules/unity_catalog/provider.tf
@@ -18,18 +18,18 @@ provider "google" {
 
 
 provider "databricks" {
- alias                  = "workspace"
- host                   = var.databricks_workspace_url
- google_service_account = var.databricks_google_service_account
- version = "1.18.0"
+  alias                  = "workspace"
+  host                   = var.databricks_workspace_url
+  google_service_account = var.databricks_google_service_account
+  version                = "1.18.0"
 }
 
 // initialize provider in "MWS" mode for account-level resources
 provider "databricks" {
-  alias      = "mws"
-  host       = "https://accounts.staging.gcp.databricks.com"
-  account_id = var.databricks_account_id
+  alias                  = "mws"
+  host                   = "https://accounts.staging.gcp.databricks.com"
+  account_id             = var.databricks_account_id
   google_service_account = var.databricks_google_service_account
-  version = "1.18.0"
+  version                = "1.18.0"
 }
 

--- a/gcp/modules/workspace_deployment/assign_users.tf
+++ b/gcp/modules/workspace_deployment/assign_users.tf
@@ -1,47 +1,33 @@
+# Assign var.resource_owner as a workspace admin.
+#
+# Gated by:
+#  - var.resource_owner must be set (module callers opt in)
+#  - var.skip_user_lookup must be false (used to bypass the data source during destroy,
+#    when the user may no longer exist in the account).
 
-# data "google_client_config" "current" {
-# }
+data "databricks_user" "resource_owner" {
+  count      = (var.resource_owner != "" && !var.skip_user_lookup) ? 1 : 0
+  provider   = databricks.accounts
+  user_name  = var.resource_owner
+  depends_on = [time_sleep.wait_for_workspace_apis]
+}
 
+resource "databricks_mws_permission_assignment" "resource_owner_admin" {
+  count        = (var.resource_owner != "" && !var.skip_user_lookup) ? 1 : 0
+  provider     = databricks.accounts
+  workspace_id = databricks_mws_workspaces.this.workspace_id
+  principal_id = data.databricks_user.resource_owner[0].id
+  permissions  = ["ADMIN"]
+  depends_on   = [time_sleep.wait_for_workspace_apis]
+}
 
-
-# resource "databricks_user" "me" {
-#  count = var.create_admin_user ? 1 : 0
-#  depends_on = [databricks_metastore_assignment.this]
-#  provider  = databricks.accounts
-#  user_name = var.admin_user_email
-# }
-
-# data "databricks_user" "me" {
-#  count = var.create_admin_user ? 0 : 1
-#  depends_on = [databricks_metastore_assignment.this]
-#  provider  = databricks.accounts
-#  user_name = var.admin_user_email
-# }
-
-# resource "databricks_mws_permission_assignment" "allow_me_to_login" {
-#   count = var.admin_user_email != "" ? 1 : 0
-#   provider = databricks.accounts
-#   workspace_id = databricks_mws_workspaces.this.workspace_id
-#   principal_id = var.create_admin_user? databricks_user.me[0].id : data.databricks_user.me[0].id
-#   permissions = ["ADMIN"]
-#   depends_on = [databricks_user.me]
-# }
-
-# resource "databricks_group_member" "allow_me_to_login" {
-#  count = var.admin_user_email != "" ? 1 : 0
-#  depends_on = [databricks_mws_workspaces.this,databricks_metastore_assignment.this]
-
-#  provider  = databricks.accounts
-# #  workspace_id = databricks_mws_workspaces.this.workspace_id
-#  group_id  = data.databricks_group.admins[0].id
-#  member_id = databricks_user.me[0].id
-# }
-
-
-# resource "databricks_ip_access_list" "allowed-list" {
-#   provider = databricks.workspace
-#   label     = "allow_in"
-#   list_type = "ALLOW"
+# Optional: IP access list configuration.
+# Uncomment to enable IP-based access restrictions on the workspace.
+#
+# resource "databricks_ip_access_list" "allowed_list" {
+#   provider     = databricks.workspace
+#   label        = "allow_in"
+#   list_type    = "ALLOW"
 #   ip_addresses = var.ip_addresses
-  
+#   depends_on   = [databricks_mws_workspaces.this]
 # }

--- a/gcp/modules/workspace_deployment/cmek.tf
+++ b/gcp/modules/workspace_deployment/cmek.tf
@@ -1,36 +1,34 @@
-
-# create key ring
+# Create keyring (only when we own the CMEK).
 resource "google_kms_key_ring" "databricks_key_ring" {
-    provider = google
-    count = var.use_existing_cmek ? 0 : 1
-    name     = "${var.keyring_name}-${random_string.suffix.result}"
-    location = var.google_region
-}
-
-# create key used for encryption
-resource "google_kms_crypto_key" "databricks_key" {
   provider = google
-  count = var.use_existing_cmek ? 0 : 1
-  name       = "${var.key_name}-${random_string.suffix.result}"
-  key_ring   = google_kms_key_ring.databricks_key_ring[0].id
-  purpose    = "ENCRYPT_DECRYPT"
-  rotation_period = "31536000s" # Set rotation period to 1 year in seconds, need to be greater than 1 day
-
+  count    = (var.use_cmek && !var.use_existing_cmek) ? 1 : 0
+  name     = "${var.keyring_name}-${local.deployment_suffix}"
+  location = var.google_region
 }
 
-# # assign CMEK on Databricks side
+# Create KMS key used for workspace encryption.
+resource "google_kms_crypto_key" "databricks_key" {
+  provider        = google
+  count           = (var.use_cmek && !var.use_existing_cmek) ? 1 : 0
+  name            = "${var.key_name}-${local.deployment_suffix}"
+  key_ring        = google_kms_key_ring.databricks_key_ring[0].id
+  purpose         = "ENCRYPT_DECRYPT"
+  rotation_period = "31536000s" # 1 year (must be greater than 1 day)
+}
+
+# Register the CMEK with Databricks.
 resource "databricks_mws_customer_managed_keys" "this" {
-        
-        provider = databricks.accounts
-        count = var.use_existing_cmek ? 0 : 1
-        account_id   = var.databricks_account_id
-        gcp_key_info {
-            # kms_key_id   = var.use_existing_cmek? "projects/${var.google_project}/locations/${var.google_region}/keyRings/${var.keyring_name}-${random_string.suffix.result}/cryptoKeys/${var.key_name}-${random_string.suffix.result}": google_kms_crypto_key.databricks_key[0].id
-            kms_key_id   = var.cmek_resource_id
-        }
-        use_cases = ["STORAGE","MANAGED","MANAGED_SERVICES"]
-        lifecycle {
-              ignore_changes = all
-        }
-}
+  provider   = databricks.accounts
+  count      = (var.use_cmek && !var.use_existing_cmek) ? 1 : 0
+  account_id = var.databricks_account_id
 
+  gcp_key_info {
+    kms_key_id = var.cmek_resource_id != "" ? var.cmek_resource_id : google_kms_crypto_key.databricks_key[0].id
+  }
+
+  use_cases = ["STORAGE", "MANAGED", "MANAGED_SERVICES"]
+
+  lifecycle {
+    ignore_changes = all
+  }
+}

--- a/gcp/modules/workspace_deployment/data.tf
+++ b/gcp/modules/workspace_deployment/data.tf
@@ -1,6 +1,6 @@
 
 data "google_client_openid_userinfo" "me" {
-    
+
 }
 
 

--- a/gcp/modules/workspace_deployment/metastore_assignment.tf
+++ b/gcp/modules/workspace_deployment/metastore_assignment.tf
@@ -1,8 +1,21 @@
-
 resource "databricks_metastore_assignment" "this" {
-  count = var.regional_metastore_id != "" ? 1 : 0
-  provider = databricks.accounts
-  workspace_id         = databricks_mws_workspaces.this.workspace_id
-  metastore_id         = var.regional_metastore_id
-  default_catalog_name = "default_catalog"
+  count        = var.regional_metastore_id != "" ? 1 : 0
+  provider     = databricks.accounts
+  workspace_id = databricks_mws_workspaces.this.workspace_id
+  metastore_id = var.regional_metastore_id
+}
+
+# Set the workspace's default namespace (default catalog) to an existing
+# catalog in the assigned metastore. The module does not create the catalog —
+# it must already exist. Skipped when default_catalog_name is empty, which
+# leaves the workspace at whatever default Databricks assigns.
+resource "databricks_default_namespace_setting" "this" {
+  count    = (var.regional_metastore_id != "" && var.default_catalog_name != "") ? 1 : 0
+  provider = databricks.workspace
+
+  namespace {
+    value = var.default_catalog_name
+  }
+
+  depends_on = [databricks_metastore_assignment.this]
 }

--- a/gcp/modules/workspace_deployment/outputs.tf
+++ b/gcp/modules/workspace_deployment/outputs.tf
@@ -1,9 +1,30 @@
-
-output "databricks_host" {
-  value = databricks_mws_workspaces.this.workspace_url
+output "workspace_url" {
+  description = "URL of the Databricks workspace"
+  value       = databricks_mws_workspaces.this.workspace_url
 }
 
-# output "databricks_token" {
-#   value     = databricks_mws_workspaces.this.token[0].token_value
-#   sensitive = true
-# }
+output "workspace_id" {
+  description = "Databricks workspace ID"
+  value       = databricks_mws_workspaces.this.workspace_id
+}
+
+output "workspace_name" {
+  description = "Name of the Databricks workspace"
+  value       = databricks_mws_workspaces.this.workspace_name
+}
+
+output "region" {
+  description = "GCP region where resources are deployed"
+  value       = var.google_region
+}
+
+# Backward-compatible alias for the workspace URL.
+output "databricks_host" {
+  description = "DEPRECATED: use workspace_url instead. Kept for backward compatibility."
+  value       = databricks_mws_workspaces.this.workspace_url
+}
+
+output "deployment_suffix" {
+  description = "Suffix applied to resource names (either derived from deployment_id or random)."
+  value       = local.deployment_suffix
+}

--- a/gcp/modules/workspace_deployment/outputs.tf
+++ b/gcp/modules/workspace_deployment/outputs.tf
@@ -25,6 +25,6 @@ output "databricks_host" {
 }
 
 output "deployment_suffix" {
-  description = "Suffix applied to resource names (either derived from deployment_id or random)."
+  description = "Random suffix applied to resource names."
   value       = local.deployment_suffix
 }

--- a/gcp/modules/workspace_deployment/providers.tf
+++ b/gcp/modules/workspace_deployment/providers.tf
@@ -1,8 +1,10 @@
 terraform {
+  # Note: no backend block here. This module is intended to be consumed from a
+  # root configuration (e.g. gcp/examples/*) that declares its own backend.
   required_providers {
     databricks = {
-      source = "databricks/databricks"
-      version = ">=1.51.0"
+      source                = "databricks/databricks"
+      version               = ">=1.113.0"
       configuration_aliases = [databricks.accounts]
     }
     google = {
@@ -10,29 +12,25 @@ terraform {
       version = ">=5.43.1"
     }
     time = {
-      source = "hashicorp/time"
+      source  = "hashicorp/time"
       version = "~> 0.9.1"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.5"
     }
   }
 }
 
-# Use impersonation for Google provider - this allows the module to act as the service account
+# Use impersonation for the Google provider - this allows the module to act as the service account.
 provider "google" {
   project = var.google_project
   region  = var.google_region
-  
-  # Impersonate the service account created by the service_account module
+
   impersonate_service_account = var.databricks_google_service_account != "" ? var.databricks_google_service_account : null
-  
-  # # Add explicit scopes
-  # scopes = [
-  #   "https://www.googleapis.com/auth/cloud-platform",
-  #   "https://www.googleapis.com/auth/cloudkms",
-  #   "https://www.googleapis.com/auth/compute"
-  # ]
 }
 
-// initialize provider in "accounts" mode to provision new workspace
+# Databricks provider in "accounts" mode to provision a new workspace.
 provider "databricks" {
   alias                  = "accounts"
   host                   = var.account_console_url
@@ -40,9 +38,9 @@ provider "databricks" {
   account_id             = var.databricks_account_id
 }
 
+# Databricks provider scoped to the deployed workspace.
 provider "databricks" {
   alias                  = "workspace"
   host                   = databricks_mws_workspaces.this.workspace_url
   google_service_account = var.databricks_google_service_account
 }
-

--- a/gcp/modules/workspace_deployment/psc.tf
+++ b/gcp/modules/workspace_deployment/psc.tf
@@ -1,32 +1,32 @@
 resource "google_compute_subnetwork" "backend_pe_subnetwork" {
-  count = (var.use_existing_PSC_EP || !var.use_psc) ? 0 : 1
-  name          = "pe-subnet-${random_string.suffix.result}"
+  count         = (var.use_existing_PSC_EP || var.use_existing_vpc || !var.use_psc || var.serverless_workspace_deployment) ? 0 : 1
+  name          = "${var.resource_prefix}-pe-subnet-${local.deployment_suffix}"
   ip_cidr_range = var.google_pe_subnet_ip_cidr_range
   region        = var.google_region
   network       = google_compute_network.dbx_private_vpc[0].id
 
   private_ip_google_access = true
 
-  depends_on=[google_compute_network.dbx_private_vpc]
+  depends_on = [google_compute_network.dbx_private_vpc]
 }
 
-
 resource "google_compute_forwarding_rule" "backend_psc_ep" {
-  count = (var.use_existing_PSC_EP || !var.use_psc) ? 0 : 1
+  count = (var.use_existing_PSC_EP || var.use_existing_vpc || !var.use_psc || var.serverless_workspace_deployment) ? 0 : 1
   depends_on = [
-    google_compute_address.backend_pe_ip_address, google_compute_network.dbx_private_vpc
+    google_compute_address.backend_pe_ip_address,
+    google_compute_network.dbx_private_vpc,
   ]
-  region      = var.google_region
-  project     = var.google_project
-  name        = var.relay_pe
-  network     = google_compute_network.dbx_private_vpc[0].id
-  ip_address  = google_compute_address.backend_pe_ip_address[0].id
-  target      = var.relay_service_attachment
-  load_balancing_scheme = "" #This field must be set to "" if the target is an URI of a service attachment. Default value is EXTERNAL
+  region                = var.google_region
+  project               = var.google_project
+  name                  = var.relay_pe
+  network               = google_compute_network.dbx_private_vpc[0].id
+  ip_address            = google_compute_address.backend_pe_ip_address[0].id
+  target                = var.relay_service_attachment
+  load_balancing_scheme = "" # Must be "" when target is a service attachment URI.
 }
 
 resource "google_compute_address" "backend_pe_ip_address" {
-  count = (var.use_existing_PSC_EP || !var.use_psc) ? 0 : 1
+  count        = (var.use_existing_PSC_EP || var.use_existing_vpc || !var.use_psc || var.serverless_workspace_deployment) ? 0 : 1
   name         = var.relay_pe_ip_name
   provider     = google
   project      = var.google_project
@@ -36,24 +36,23 @@ resource "google_compute_address" "backend_pe_ip_address" {
 }
 
 resource "google_compute_forwarding_rule" "frontend_psc_ep" {
-  count = (var.use_existing_PSC_EP || !var.use_psc) ? 0 : 1
+  count = (var.use_existing_PSC_EP || var.use_existing_vpc || !var.use_psc || var.serverless_workspace_deployment) ? 0 : 1
 
   depends_on = [
-    google_compute_address.frontend_pe_ip_address
+    google_compute_address.frontend_pe_ip_address,
   ]
-  region      = var.google_region
-  name        = var.workspace_pe
-  project     = var.google_project
-  network     = google_compute_network.dbx_private_vpc[0].id
-
-  ip_address  = google_compute_address.frontend_pe_ip_address[0].id
-  target      = var.workspace_service_attachment
-  load_balancing_scheme = "" #This field must be set to "" if the target is an URI of a service attachment. Default value is EXTERNAL
+  region                = var.google_region
+  name                  = var.workspace_pe
+  project               = var.google_project
+  network               = google_compute_network.dbx_private_vpc[0].id
+  ip_address            = google_compute_address.frontend_pe_ip_address[0].id
+  target                = var.workspace_service_attachment
+  load_balancing_scheme = "" # Must be "" when target is a service attachment URI.
 }
 
 resource "google_compute_address" "frontend_pe_ip_address" {
-  count = (var.use_existing_PSC_EP || !var.use_psc) ? 0 : 1
-  
+  count = (var.use_existing_PSC_EP || var.use_existing_vpc || !var.use_psc || var.serverless_workspace_deployment) ? 0 : 1
+
   name         = var.workspace_pe_ip_name
   provider     = google
   project      = var.google_project
@@ -62,39 +61,130 @@ resource "google_compute_address" "frontend_pe_ip_address" {
   address_type = "INTERNAL"
 }
 
+# Register the GCP PSC forwarding rules with the Databricks account.
+# Created whenever use_psc = true and the caller does NOT want to reuse an
+# existing Databricks-side registration — independent of whether the GCP PSC
+# forwarding rules were created by this module or supplied via BYO-VPC.
 resource "databricks_mws_vpc_endpoint" "backend_rest_vpce" {
-  count = (var.use_psc && !var.use_existing_databricks_vpc_eps) ? 1 : 0
-  depends_on =[google_compute_forwarding_rule.backend_psc_ep]
-  provider     = databricks.accounts
-  account_id          = var.databricks_account_id
-  vpc_endpoint_name   = "vpce-backend-rest"
+  count = (var.use_psc && !var.use_existing_databricks_vpc_eps && !var.serverless_workspace_deployment) ? 1 : 0
+
+  provider          = databricks.accounts
+  account_id        = var.databricks_account_id
+  vpc_endpoint_name = "vpce-backend-rest-${local.deployment_suffix}"
+
   gcp_vpc_endpoint_info {
-   project_id        = var.google_project
-   psc_endpoint_name = var.workspace_pe
-   endpoint_region   = google_compute_subnetwork.network-with-private-secondary-ip-ranges[0].region
- }
+    project_id        = var.google_project
+    psc_endpoint_name = var.workspace_pe
+    endpoint_region   = var.google_region
+  }
+
+  # No-op wait when the forwarding rule is BYO (count = 0 resource).
+  depends_on = [google_compute_forwarding_rule.frontend_psc_ep]
 }
 
 resource "databricks_mws_vpc_endpoint" "relay_vpce" {
-  count = (var.use_psc && !var.use_existing_databricks_vpc_eps) ? 1 : 0
-  provider     = databricks.accounts
-  depends_on = [ google_compute_forwarding_rule.frontend_psc_ep ]
-  account_id          = var.databricks_account_id
-  vpc_endpoint_name   = "vpce-relay"
+  count = (var.use_psc && !var.use_existing_databricks_vpc_eps && !var.serverless_workspace_deployment) ? 1 : 0
+
+  provider          = databricks.accounts
+  account_id        = var.databricks_account_id
+  vpc_endpoint_name = "vpce-relay-${local.deployment_suffix}"
+
   gcp_vpc_endpoint_info {
     project_id        = var.google_project
     psc_endpoint_name = var.relay_pe
-    endpoint_region   = google_compute_subnetwork.network-with-private-secondary-ip-ranges[0].region
- }
-}
-output "front_end_psc_status" {
-  value = var.use_psc ? (
-    "Frontend psc status: ${var.use_existing_PSC_EP ? "Pre-provisioned" : google_compute_forwarding_rule.frontend_psc_ep[0].psc_connection_status}"
-  ) : "PSC not in use"
+    endpoint_region   = var.google_region
+  }
+
+  depends_on = [google_compute_forwarding_rule.backend_psc_ep]
 }
 
-output "backend_end_psc_status" {
-  value = var.use_psc ? (
-    "Backend psc status: ${var.use_existing_PSC_EP ? "Pre-provisioned" : google_compute_forwarding_rule.backend_psc_ep[0].psc_connection_status}"
-  ) : "PSC not in use"
+# =============================================================================
+# DNS zone + records for the PSC workspace
+#
+# Three modes (driven by create_dns_zone and existing_dns_zone_name):
+#   1. create_dns_zone = true            -> module creates zone + A-records
+#   2. existing_dns_zone_name set        -> module creates A-records in that zone
+#   3. both unset                        -> module creates nothing (user manages DNS)
+#
+# If both are set, create_dns_zone wins and existing_dns_zone_name is ignored.
+# =============================================================================
+
+locals {
+  # Whether to manage DNS records. Must depend only on input variables so that
+  # Terraform can evaluate count at plan time (no computed attributes).
+  manage_dns_records = var.use_psc && !var.serverless_workspace_deployment && (var.create_dns_zone || var.existing_dns_zone_name != "")
+
+  # Resolve the managed zone name — used in the record resources' managed_zone
+  # argument (evaluated at apply time, not in count).
+  dns_managed_zone_name = var.create_dns_zone ? (
+    length(google_dns_managed_zone.databricks_private_zone) > 0 ? google_dns_managed_zone.databricks_private_zone[0].name : ""
+  ) : var.existing_dns_zone_name
+
+  # Choose which IP to use in the DNS A-records.
+  workspace_psc_ip = var.use_existing_PSC_EP ? var.existing_workspace_psc_endpoint_ip : (
+    length(google_compute_address.frontend_pe_ip_address) > 0 ? google_compute_address.frontend_pe_ip_address[0].address : ""
+  )
+
+  # Relay (SCC tunnel) PSC IP — used for the tunnel.<region> A-record.
+  relay_psc_ip = var.use_existing_PSC_EP ? var.existing_relay_psc_endpoint_ip : (
+    length(google_compute_address.backend_pe_ip_address) > 0 ? google_compute_address.backend_pe_ip_address[0].address : ""
+  )
+}
+
+# Mode 1: create a private DNS zone for gcp.databricks.com attached to this workspace's VPC.
+resource "google_dns_managed_zone" "databricks_private_zone" {
+  count = (var.use_psc && var.create_dns_zone && !var.serverless_workspace_deployment) ? 1 : 0
+
+  name        = var.dns_zone_name
+  project     = var.google_project
+  dns_name    = "gcp.databricks.com."
+  description = "Private DNS zone for Databricks PSC workspace"
+  visibility  = "private"
+
+  private_visibility_config {
+    networks {
+      network_url = local.vpc_self_link
+    }
+  }
+}
+
+# A-record for the workspace URL.
+resource "google_dns_record_set" "workspace_dns" {
+  count = local.manage_dns_records ? 1 : 0
+
+  depends_on = [databricks_mws_workspaces.this]
+
+  project      = var.google_project
+  name         = "${databricks_mws_workspaces.this.workspace_id}.${substr(databricks_mws_workspaces.this.workspace_id, -1, 1)}.gcp.databricks.com."
+  type         = "A"
+  ttl          = 300
+  managed_zone = local.dns_managed_zone_name
+  rrdatas      = [local.workspace_psc_ip]
+}
+
+# A-record for the dp- prefixed workspace URL.
+resource "google_dns_record_set" "dp_workspace_dns" {
+  count = local.manage_dns_records ? 1 : 0
+
+  depends_on = [databricks_mws_workspaces.this]
+
+  project      = var.google_project
+  name         = "dp-${databricks_mws_workspaces.this.workspace_id}.${substr(databricks_mws_workspaces.this.workspace_id, -1, 1)}.gcp.databricks.com."
+  type         = "A"
+  ttl          = 300
+  managed_zone = local.dns_managed_zone_name
+  rrdatas      = [local.workspace_psc_ip]
+}
+
+# A-record for the SCC relay tunnel endpoint. Cluster VMs use this to
+# establish the secure tunnel back to the Databricks control plane.
+resource "google_dns_record_set" "tunnel_dns" {
+  count = local.manage_dns_records ? 1 : 0
+
+  project      = var.google_project
+  name         = "tunnel.${var.google_region}.gcp.databricks.com."
+  type         = "A"
+  ttl          = 300
+  managed_zone = local.dns_managed_zone_name
+  rrdatas      = [local.relay_psc_ip]
 }

--- a/gcp/modules/workspace_deployment/readme.md
+++ b/gcp/modules/workspace_deployment/readme.md
@@ -41,7 +41,7 @@ All module-created resources use the format:
 ```
 
 - `resource_prefix` defaults to `databricks` and is configurable via `var.resource_prefix`.
-- `deployment_suffix` is derived from `var.deployment_id` (first 8 chars) if set, otherwise a random 8-char suffix is generated.
+- `deployment_suffix` is a random 6-char alphanumeric string generated once and stored in state.
 
 ## Variables
 
@@ -52,7 +52,6 @@ All module-created resources use the format:
 - `google_project`, `google_region` — GCP project and region.
 - `account_console_url` — Defaults to `https://accounts.gcp.databricks.com`.
 - `workspace_name` — Name of the workspace to create.
-- `deployment_id` — Optional. Unique ID used for naming. If empty, a random suffix is generated.
 - `resource_prefix` — Prefix for all resources. Defaults to `databricks`.
 
 ### Compute mode
@@ -65,6 +64,7 @@ All module-created resources use the format:
 - `existing_vpc_name`, `existing_subnet_name` — Required when `use_existing_vpc = true`.
 - `nodes_ip_cidr_range` — CIDR for nodes (immutable after creation).
 - `harden_network` — Enables a set of egress/ingress firewall rules. A new `db-<subnet>-ingress` rule is created (for non-serverless, non-BYO-VPC deployments only) so that Databricks does not create its own firewall rule. When `use_existing_vpc = true` the module creates **no** GCP firewalls — you are responsible for providing the rules Databricks requires on the VPC you bring.
+- `databricks_control_plane_ips` — Regional control-plane IPs used in the egress firewall rule when `harden_network = true` and `use_psc = false`. Look up the values for your region at [IP addresses and domains](https://docs.databricks.com/gcp/en/resources/ip-domain-region).
 
 ### PSC / connectivity
 
@@ -170,7 +170,7 @@ Variables:
 - `workspace_id` — Workspace ID.
 - `workspace_name` — Workspace name.
 - `region` — GCP region.
-- `deployment_suffix` — Effective naming suffix used by the module.
+- `deployment_suffix` — Random suffix used for resource naming.
 - `databricks_host` — Deprecated alias for `workspace_url`.
 
 ## Upgrading from a previous version of this module

--- a/gcp/modules/workspace_deployment/readme.md
+++ b/gcp/modules/workspace_deployment/readme.md
@@ -1,50 +1,204 @@
 ---
-page_title: "Workspace Deployment GCP SRA Modue"
+page_title: "Workspace Deployment GCP SRA Module"
 ---
 
-# Module to deploy a Databricks workspace 
+# Module to deploy a Databricks workspace on GCP
 
-This module is provided as-is and you can use this guide as the basis for your custom Terraform module. This module is meant to be used either to provision a workspace with all the required GCP objects associated or to leverage existing objects, thus enabling use cases where CMEK, PSCs, and other artefacts that require higher privileges need to be provisionned through an external process and can't be provisionned through terraform.
-The example folder aims at illustrating this through different use cases.
+This module provisions a Databricks workspace on Google Cloud. It supports:
+
+- **Classic and serverless** workspaces.
+- **Create-from-scratch** or **bring-your-own** for VPC, PSC endpoints, Private Access Settings, CMEK keys, and DNS zones.
+- **Three DNS modes** for PSC workspaces: module creates zone + records, module creates records in an existing zone, or module creates nothing (manual DNS).
+- **Hardened network** with optional firewall rules.
+- **Workspace hardening** (IP access lists, verbose audit logs, DBFS file browser disabled, 90-day token lifetime).
+- **Optional resource_owner admin assignment** at the workspace level.
 
 ## Requirements
-Running this module has the following requirements :
-- Recent version of Terraform 
-- Access to recent versions the Databricks Provider (```databricks/databricks```) and the google Provider (```hashicorp/google```)
-- A Google Service Account with the GCP privileges defined in the module service_account and added to the Databricks Account Console as a **User** with the account admin privileges
-- Depending on how much you are allowed to provision through this module, the values for the following variables
+
+- Recent version of Terraform (>= 1.5 recommended).
+- Databricks provider `>= 1.113.0` and Google provider `>= 5.43.1`.
+- A Google Service Account with the IAM roles required by the `service_account` module and added to the Databricks Account Console as an account admin.
+- A GCS bucket to hold remote state (the backend is configured as `gcs` — see `providers.tf`).
+
+## Remote state (GCS)
+
+The module declares a partial `gcs` backend. Provide the bucket/prefix at `terraform init` time, e.g.:
+
+```bash
+terraform init \
+  -backend-config="bucket=my-tfstate-bucket" \
+  -backend-config="prefix=databricks/workspace_deployment"
+```
+
+If you want to use a different backend, override `providers.tf` in your consuming configuration or remove the `backend "gcs" {}` block.
+
+## Resource naming
+
+All module-created resources use the format:
+
+```
+<resource_prefix>-<resource>-<deployment_suffix>
+```
+
+- `resource_prefix` defaults to `databricks` and is configurable via `var.resource_prefix`.
+- `deployment_suffix` is derived from `var.deployment_id` (first 8 chars) if set, otherwise a random 8-char suffix is generated.
 
 ## Variables
 
-This module uses the following variables in configurations:
+### General
 
-- `databricks_account_id`: The ID per Databricks GCP account used for accessing account management APIs. After the GCP account is created, this is available after logging into [https://accounts.cloud.databricks.com](https://accounts.cloud.databricks.com).
-- `databricks_google_service_account`: Service account used for programatically interacting with cloud infrastructure. More documentation [here](https://cloud.google.com/iam/docs/service-accounts)
-- `google_project` - The name of the GCP project where the workspace is deployed.
-- `google_region` - Region in which infrastructure is spun up.
-- `account_console_url` - Databricks account console URL (always the same for a given cloud)
-- `workspace_name` - Name you want to give to the Databricks workspace you are creating
-- `use_existing_vpc` - Flag determining if you will be creating the VPC as a part of this module (you may provide an existing one).
-- `existing_vpc_name` - Name of the VPC if use_existing_vpc=true. If use_existing_vpc=false, we are generating a random name.
-- `existing_subnet_name` - Name of the subnet if use_existing_vpc=true. If use_existing_vpc=false, we are generating a random name.
-- `nodes_ip_cidr_range` - CIDR range for nodes. See https://docs.databricks.com/gcp/en/admin/cloud-configurations/gcp/network-sizing for sizing details. This is important as it can't be changed after the workspace is created.
-- `use_existing_PSC_EP` - Flag determining if you will be creating PSC Endpoints as a part of this module (you may provide an existing one). 
-- `google_pe_subnet` - Name of the subnet where the PSC Endpoints will be provided
-- `google_pe_subnet_ip_cidr_range` - CIDR of the PE subnet. Needed only if use_existing_PSC_EP=false
-- `workspace_pe` - Name of the PSC endpoint used for the workspace communication. If you are creating it you may decide its value. 
-- `relay_pe` - Name of the PSC endpoint used for the SCC relay communication. If you are creating it you may decide its value. 
-- `workspace_pe_ip_name` - Name of the workspace private endpoint IP.If use_existing_PSC_EP = true, not needed. If use_existing_PSC_EP = true, you may decide its value.
-- `relay_pe_ip_name` - Name of the Relay IP. If use_existing_PSC_EP = true, not needed. If use_existing_PSC_EP = true, you may decide its value.
-- `harden_network` - Flag determining if we are closing VPC access by default and only opening the minimum required communication.
-- `hive_metastore_ip` - IP to the regional Metastore. This value can be found here - https://docs.gcp.databricks.com/en/resources/ip-domain-region.html#addresses-for-default-metastore. The module will create an Egress opening to this IP Address. This will be soon deprecated as we are shifting away from this communication.
-- `ip_addresses` - list of IP addresses from which to access the workspace.
-- `use_existing_pas` - flag to use an existing Private Access Settings (Databricks Object)
-- `existing_pas_id` - if above is true, the ID of the setting (found in the account console)
-- `relay_service_attachment` - Relay service attachment. regional values - https://docs.gcp.databricks.com/resources/supported-regions.html#psc
-- `workspace_service_attachment` - Workspace service attachment. Regional values - https://docs.gcp.databricks.com/resources/supported-regions.html#psc
+- `databricks_account_id` — Databricks account ID.
+- `databricks_google_service_account` — Service account used to impersonate.
+- `google_project`, `google_region` — GCP project and region.
+- `account_console_url` — Defaults to `https://accounts.gcp.databricks.com`.
+- `workspace_name` — Name of the workspace to create.
+- `deployment_id` — Optional. Unique ID used for naming. If empty, a random suffix is generated.
+- `resource_prefix` — Prefix for all resources. Defaults to `databricks`.
 
-- `use_existing_cmek` - flag ("true" or "false") allowing for either the mode where you provide the resource ID to your CMEK resource, or let the module create a new one by providing key_name and keyring_name
-- `key_name` & `keyring_name` - name to be given to the CMEK used by Databricks for encryption. Not useful if bringing an existing `cmek_resource_id`
-- `cmek_resource_id` - ID to your existing CMEK. Only needed if use_existing_cmek = true
+### Compute mode
 
+- `serverless_workspace_deployment` — When `true`, skips all VPC/PSC/network configuration and deploys a serverless workspace.
 
+### Networking
+
+- `use_existing_vpc` — Reuse an existing VPC.
+- `existing_vpc_name`, `existing_subnet_name` — Required when `use_existing_vpc = true`.
+- `nodes_ip_cidr_range` — CIDR for nodes (immutable after creation).
+- `harden_network` — Enables a set of egress/ingress firewall rules. A new `db-<subnet>-ingress` rule is created (for non-serverless, non-BYO-VPC deployments only) so that Databricks does not create its own firewall rule. When `use_existing_vpc = true` the module creates **no** GCP firewalls — you are responsible for providing the rules Databricks requires on the VPC you bring.
+
+### PSC / connectivity
+
+- `use_psc` — Enable backend Private Service Connect.
+- `use_frontend_psc` — Enable frontend Private Service Connect.
+- `use_existing_PSC_EP`, `existing_workspace_psc_endpoint_ip` — Reuse an existing PSC endpoint and its IP.
+- `workspace_pe`, `relay_pe`, `workspace_pe_ip_name`, `relay_pe_ip_name`, `workspace_service_attachment`, `relay_service_attachment` — PSC-related names and attachments.
+- `google_pe_subnet_ip_cidr_range` — CIDR for the PSC endpoint subnet.
+- `use_existing_databricks_vpc_eps`, `existing_databricks_vpc_ep_workspace`, `existing_databricks_vpc_ep_relay` — Reuse existing Databricks VPC endpoints.
+- `use_existing_pas`, `existing_pas_id` — Reuse an existing Private Access Settings.
+
+### DNS (three modes)
+
+| `create_dns_zone` | `existing_dns_zone_name` | Behavior |
+|---|---|---|
+| `true` | ignored | Module creates a private DNS zone (`var.dns_zone_name`) for `gcp.databricks.com.` and writes workspace + tunnel A-records into it. |
+| `false` | set | Module writes A-records into the existing zone you provide. |
+| `false` | empty (default) | Module creates nothing — you manage DNS manually. |
+
+When DNS is managed (mode 1 or 2), the module creates **three** A-records:
+
+| Record | Points to | Purpose |
+|---|---|---|
+| `<workspace_id>.<shard>.gcp.databricks.com.` | Workspace PSC IP | Workspace web UI and REST API |
+| `dp-<workspace_id>.<shard>.gcp.databricks.com.` | Workspace PSC IP | Data plane workspace URL |
+| `tunnel.<region>.gcp.databricks.com.` | Relay PSC IP | SCC relay — cluster VMs use this to establish the secure tunnel back to the control plane |
+
+Variables:
+
+- `create_dns_zone` — defaults to `false`.
+- `dns_zone_name` — defaults to `databricks-private-zone`.
+- `existing_dns_zone_name` — defaults to `""`.
+- `existing_relay_psc_endpoint_ip` — IP of an existing relay PSC endpoint (only needed when `use_existing_PSC_EP = true`).
+
+> **Important — Private Google Access and `googleapis.com` DNS:**
+> PSC workspaces require the VPC to have access to Google APIs (GCS, IAM, KMS,
+> Container Registry, etc.) via Private Google Access. This module enables
+> `private_ip_google_access = true` on the workspace subnet it creates, and the
+> hardened firewall allows egress to `199.36.153.4/30` (restricted Google APIs).
+>
+> However, **you must also ensure that the VPC can resolve `*.googleapis.com`
+> to the restricted (or private) Google APIs range**. If your VPC does not
+> have a private DNS zone for `googleapis.com` pointing to `199.36.153.4/30`
+> (restricted) or `199.36.153.8/30` (private), the cluster VMs will fail to
+> reach GCS and other Google services during bootstrap — even though the
+> firewall allows the traffic.
+>
+> This module does **not** create the `googleapis.com` DNS zone because it is
+> typically shared across all workloads in a VPC, not scoped to a single
+> Databricks workspace. You can create it with:
+>
+> ```hcl
+> resource "google_dns_managed_zone" "googleapis" {
+>   name        = "googleapis"
+>   project     = var.google_project
+>   dns_name    = "googleapis.com."
+>   visibility  = "private"
+>   private_visibility_config {
+>     networks { network_url = google_compute_network.your_vpc.self_link }
+>   }
+> }
+> resource "google_dns_record_set" "googleapis_a" {
+>   project      = var.google_project
+>   name         = "restricted.googleapis.com."
+>   type         = "A"
+>   ttl          = 300
+>   managed_zone = google_dns_managed_zone.googleapis.name
+>   rrdatas      = ["199.36.153.4", "199.36.153.5", "199.36.153.6", "199.36.153.7"]
+> }
+> resource "google_dns_record_set" "googleapis_cname" {
+>   project      = var.google_project
+>   name         = "*.googleapis.com."
+>   type         = "CNAME"
+>   ttl          = 300
+>   managed_zone = google_dns_managed_zone.googleapis.name
+>   rrdatas      = ["restricted.googleapis.com."]
+> }
+> ```
+>
+> For BYO-VPC deployments, verify this zone already exists in your VPC before
+> deploying with PSC + hardened network.
+
+### CMEK
+
+- `use_cmek` — Master flag (defaults to `false`).
+- `use_existing_cmek` — Reuse an existing CMEK; requires `cmek_resource_id`.
+- `key_name`, `keyring_name` — Names used when creating a new CMEK.
+- `cmek_resource_id` — Full resource ID of an existing CMEK.
+
+### Admin assignment
+
+- `resource_owner` — Email of a user to be granted workspace ADMIN.
+- `skip_user_lookup` — Set `true` during destroy if the user no longer exists.
+
+### Unity Catalog / Metastore
+
+- `regional_metastore_id` — If set, the workspace is attached to this metastore.
+- `default_catalog_name` — Existing catalog to set as the workspace's default namespace. Defaults to `"default_catalog"` (the Databricks auto-created catalog). Set to any other existing catalog name to point the workspace at it, or `""` to skip managing the default namespace. **The module does not create the catalog** — it must already exist in the metastore.
+
+## Outputs
+
+- `workspace_url` — Workspace URL.
+- `workspace_id` — Workspace ID.
+- `workspace_name` — Workspace name.
+- `region` — GCP region.
+- `deployment_suffix` — Effective naming suffix used by the module.
+- `databricks_host` — Deprecated alias for `workspace_url`.
+
+## Upgrading from a previous version of this module
+
+This revision renames most module-managed GCP resources to a uniform
+`${resource_prefix}-<resource>-${deployment_suffix}` scheme (e.g. the VPC went
+from `databricks-workspace-vpc-<suffix>` to `databricks-vpc-<suffix>`). The
+random suffix length was preserved (6 chars) so the **suffix itself does not
+change**, but the names still differ.
+
+If you have an existing state, `terraform plan` will show those resources being
+destroyed and recreated — which would tear the workspace down. You have two
+options:
+
+1. **Accept the recreation** (simplest). Destroy and redeploy in a maintenance
+   window.
+2. **Preserve state with `terraform state mv`**. For every renamed resource,
+   rename the address in state, e.g.:
+
+   ```bash
+   terraform state mv \
+     'module.customer_managed_vpc.google_compute_network.dbx_private_vpc[0]' \
+     'module.customer_managed_vpc.google_compute_network.dbx_private_vpc[0]'   # no-op example
+   ```
+
+   and update the GCP resource name via a one-off `terraform apply` + API
+   rename, or simply set `var.resource_prefix` to `"databricks-workspace"` (for
+   VPC/subnet) — note that router/NAT/PAS/PE-subnet/network-config names still
+   differ and cannot be reconciled without state surgery.
+
+For brand-new deployments, no migration is required.

--- a/gcp/modules/workspace_deployment/variables.auto.tfvars.example
+++ b/gcp/modules/workspace_deployment/variables.auto.tfvars.example
@@ -11,7 +11,6 @@ account_console_url               = "https://accounts.gcp.databricks.com"
 # ============================================================
 # Naming (optional)
 # ============================================================
-# deployment_id   = "<uuid-from-backend>"    # first 8 chars used as suffix; leave empty to auto-generate
 # resource_prefix = "databricks"             # prefix for all resources created by this module
 
 # ============================================================
@@ -28,6 +27,10 @@ account_console_url               = "https://accounts.gcp.databricks.com"
 # nodes_ip_cidr_range  = "10.0.0.0/16"
 # harden_network       = true
 # ip_addresses         = ["0.0.0.0/0"]
+
+# Control-plane IPs for egress firewall (required when harden_network = true and use_psc = false).
+# Look up the IPs for your region: https://docs.databricks.com/gcp/en/resources/ip-domain-region
+# databricks_control_plane_ips = ["x.x.x.x/32", "y.y.y.y/32"]
 
 # ============================================================
 # PSC

--- a/gcp/modules/workspace_deployment/variables.auto.tfvars.example
+++ b/gcp/modules/workspace_deployment/variables.auto.tfvars.example
@@ -1,22 +1,87 @@
-databricks_account_id = "<your-databricks-account-id>"
+# ============================================================
+# Core identifiers
+# ============================================================
+databricks_account_id             = "<your-databricks-account-id>"
 databricks_google_service_account = "<service-account-name>@<project-name>.iam.gserviceaccount.com"
-google_project = "<your-gcp-project-id>"
-google_region = "<your-gcp-region>"
-ip_addresses = ["0.0.0.0/0"]
-workspace_name = "<your-workspace-name>"
-account_console_url = "https://accounts.gcp.databricks.com"
-google_pe_subnet = "<your-pe-subnet-name>"
-hive_metastore_ip = "34.76.244.202"
-key_name = "<your-kms-key-name>"
-use_existing_cmek = true
-workspace_pe = "<your-workspace-pe-name>"
-relay_pe = "<your-relay-pe-name>"
-relay_pe_ip_name = "<your-relay-pe-ip-name>"
-use_existing_pas = false
-use_existing_PSC_EP = false
-workspace_pe_ip_name = "<your-workspace-pe-ip-name>"
-relay_service_attachment = "projects/prod-gcp-<region>/regions/<region>/serviceAttachments/ngrok-psc-endpoint"
-workspace_service_attachment = "projects/general-prod-<region>/regions/<region>/serviceAttachments/plproxy-psc-endpoint-all-ports"
-keyring_name = "<your-kms-keyring-name>"    
-cmek_resource_id = "projects/<project-name>/locations/<region>/keyRings/<keyring-name>/cryptoKeys/<key-name>"
-admin_user_email = "<admin-user-email@company.com>"
+google_project                    = "<your-gcp-project-id>"
+google_region                     = "<your-gcp-region>"
+workspace_name                    = "<your-workspace-name>"
+account_console_url               = "https://accounts.gcp.databricks.com"
+
+# ============================================================
+# Naming (optional)
+# ============================================================
+# deployment_id   = "<uuid-from-backend>"    # first 8 chars used as suffix; leave empty to auto-generate
+# resource_prefix = "databricks"             # prefix for all resources created by this module
+
+# ============================================================
+# Workspace admin
+# ============================================================
+# resource_owner = "<admin-user-email@company.com>"
+
+# ============================================================
+# Networking (classic workspace)
+# ============================================================
+# use_existing_vpc     = false
+# existing_vpc_name    = ""
+# existing_subnet_name = ""
+# nodes_ip_cidr_range  = "10.0.0.0/16"
+# harden_network       = true
+# ip_addresses         = ["0.0.0.0/0"]
+
+# ============================================================
+# PSC
+# ============================================================
+# use_psc                         = false
+# use_frontend_psc                = false
+# use_existing_PSC_EP             = false
+# use_existing_databricks_vpc_eps = false
+
+# workspace_pe                 = "<your-workspace-pe-name>"
+# relay_pe                     = "<your-relay-pe-name>"
+# workspace_pe_ip_name         = "<your-workspace-pe-ip-name>"
+# relay_pe_ip_name             = "<your-relay-pe-ip-name>"
+# workspace_service_attachment = "projects/general-prod-<region>/regions/<region>/serviceAttachments/plproxy-psc-endpoint-all-ports"
+# relay_service_attachment     = "projects/prod-gcp-<region>/regions/<region>/serviceAttachments/ngrok-psc-endpoint"
+# existing_workspace_psc_endpoint_ip = ""
+
+# use_existing_pas = false
+# existing_pas_id  = ""
+
+# ============================================================
+# DNS (three modes)
+# ============================================================
+# Mode 1: module creates zone + A-records
+# create_dns_zone = true
+# dns_zone_name   = "databricks-private-zone"
+#
+# Mode 2: module writes A-records into an existing zone
+# existing_dns_zone_name = "my-existing-dns-zone"
+#
+# Mode 3: module creates nothing (manage DNS manually) — leave both unset
+
+# ============================================================
+# CMEK
+# ============================================================
+# use_cmek          = false
+# use_existing_cmek = false
+# key_name          = "sra-key"
+# keyring_name      = "sra-keyring"
+# cmek_resource_id  = "projects/<project>/locations/<region>/keyRings/<keyring>/cryptoKeys/<key>"
+
+# ============================================================
+# Serverless
+# ============================================================
+# serverless_workspace_deployment = false
+
+# ============================================================
+# Unity Catalog
+# ============================================================
+# regional_metastore_id = "<metastore-id>"
+
+# Workspace default namespace (default catalog). Must already exist in the
+# metastore — the module does NOT create catalogs.
+#   "default_catalog" (default) — Databricks auto-created catalog.
+#   "<any-existing-catalog>"    — point the workspace at an existing catalog.
+#   ""                           — don't manage the default namespace.
+# default_catalog_name = "default_catalog"

--- a/gcp/modules/workspace_deployment/variables.tf
+++ b/gcp/modules/workspace_deployment/variables.tf
@@ -1,181 +1,320 @@
 
 ##### GENERAL VARIABLES #####
 variable "databricks_account_id" {
-    # Databricks account ID (found in the account console)
-} 
+  # Databricks account ID (found in the account console)
+}
+
 variable "databricks_google_service_account" {
-    # Google service account for Databricks
-    # This service account must have the "Databricks Workspace Creatore" role or equivalent
-    # and the "Databricks Account Admin" role in the Databricks account console
-} 
+  # Google service account for Databricks
+  # This service account must have the "Databricks Workspace Creator" role or equivalent
+  # and the "Databricks Account Admin" role in the Databricks account console
+}
 
 variable "google_project" {
-    # Name of the Google Cloud project
-} 
-variable "google_region" {
-    # Google Cloud project ID
-} 
-
-## TODO : default value not a variable
-variable "account_console_url" {
-    default = "https://accounts.gcp.databricks.com" # Databricks account console URL
-} 
-variable "workspace_name" { 
-    # Name you want to give to the Databricks workspace you are creating
-    default = "sra-deployed-ws"
+  # Name of the Google Cloud project
 }
-resource "random_string" "suffix" { 
-    # Random string generator for suffix used in resource names.
-    special = false
-    upper   = false
-    length  = 6
+
+variable "google_region" {
+  # Google Cloud region
+}
+
+variable "account_console_url" {
+  # Databricks account console URL
+  default = "https://accounts.gcp.databricks.com"
+}
+
+variable "workspace_name" {
+  # Name you want to give to the Databricks workspace you are creating
+  default = "sra-deployed-ws"
 }
 
 variable "databricks_google_service_account_key" {
-    # Base64 encoded service account key for the Google service account
-    # This is optional and can be used if you want to authenticate using a key file
-    default = ""
+  # Base64 encoded service account key for the Google service account
+  # This is optional and can be used if you want to authenticate using a key file
+  default = ""
 }
 
+##### NAMING VARIABLES #####
+variable "deployment_id" {
+  # Unique deployment ID used for naming. If empty, a random suffix is generated.
+  # When provided (e.g., a UUID from a backend), the first 8 characters are used.
+  type        = string
+  default     = ""
+  description = "Unique deployment ID. Leave empty to auto-generate a random 8-char suffix."
+}
+
+variable "resource_prefix" {
+  # Prefix applied to resource names. Final format: <prefix>-<resource>-<deployment_suffix>
+  type        = string
+  default     = "databricks"
+  description = "Prefix for all resource names created by this module."
+}
+
+resource "random_string" "suffix" {
+  # Fallback suffix when var.deployment_id is not provided.
+  # Length kept at 6 to match the legacy behavior so existing deployments do
+  # not see the suffix regenerate on upgrade.
+  count   = var.deployment_id == "" ? 1 : 0
+  special = false
+  upper   = false
+  length  = 6
+}
+
+locals {
+  deployment_suffix = var.deployment_id != "" ? substr(var.deployment_id, 0, 8) : random_string.suffix[0].result
+}
 
 ##### NETWORKING VARIABLES #####
-variable "use_existing_vpc" { 
-    # Flag to use an existing VPC
-    default = false
+variable "use_existing_vpc" {
+  # Flag to use an existing VPC
+  default = false
 }
-variable "existing_vpc_name" { 
-    # Name of the existing VPC. Keep it empty if you want to create a new one.
-    default = ""
+
+variable "existing_vpc_name" {
+  # Name of the existing VPC. Keep it empty if you want to create a new one.
+  default = ""
 }
-variable "existing_subnet_name" { 
-    # Name of the existing subnet. Keep it empty if you want to create a new one.
-    default = ""
+
+variable "existing_subnet_name" {
+  # Name of the existing subnet. Keep it empty if you want to create a new one.
+  default = ""
 }
-variable "nodes_ip_cidr_range" { 
-    # CIDR range for nodes. See https://docs.databricks.com/gcp/en/admin/cloud-configurations/gcp/network-sizing for sizing details.
-    # This is important as it can't be changed after the workspace is created.
-    default = "10.0.0.0/16"
+
+variable "nodes_ip_cidr_range" {
+  # CIDR range for nodes. See https://docs.databricks.com/gcp/en/admin/cloud-configurations/gcp/network-sizing
+  # Important: this cannot be changed after the workspace is created.
+  default = "10.0.0.0/16"
 }
-variable "use_existing_PSC_EP" { 
-    # Flag to use an existing PSC endpoint
-    default = false
+
+variable "use_existing_PSC_EP" {
+  # Flag to use an existing PSC endpoint
+  default = false
 }
+
 variable "google_pe_subnet" {
-    #Name of the subnet to be used for the PSC endpoints
-    default = "databricks-pe-subnet"
-} 
-variable "google_pe_subnet_ip_cidr_range" { 
-    # CIDR range for private endpoint subnet
-    default = "10.3.0.0/24"
+  # Name of the subnet to be used for the PSC endpoints
+  default = "databricks-pe-subnet"
 }
+
+variable "google_pe_subnet_ip_cidr_range" {
+  # CIDR range for private endpoint subnet
+  default = "10.3.0.0/24"
+}
+
 variable "workspace_pe" {
-    # Name of the PSC endpoint (found in GCP console) used for the workspace communication
-    default = "worskspace-pe"
-}   
+  # Name of the PSC endpoint (found in GCP console) used for the workspace communication
+  default = "workspace-pe"
+}
+
 variable "relay_pe" {
-    # Name of the PSC endpoint (found in the GCP console) used for the relay communication
-    default = "relay-pe"
-} 
+  # Name of the PSC endpoint (found in the GCP console) used for the relay communication
+  default = "relay-pe"
+}
+
 variable "workspace_pe_ip_name" {
-    # Workspace private endpoint IP name
-    default = ""
-} 
+  # Workspace private endpoint IP name
+  default = ""
+}
+
 variable "relay_pe_ip_name" {
-    # Name of the relay private endpoint IP
-    default = ""
-} 
-variable "harden_network" { 
-    # Flag to enable network hardening with firewalls rules
-    default = true
+  # Name of the relay private endpoint IP
+  default = ""
 }
+
+variable "harden_network" {
+  # Flag to enable network hardening with firewall rules
+  default = true
+}
+
 variable "hive_metastore_ip" {
-    # For the value of the regional Hive Metastore IP, refer to the Databricks documentation
-    # Here - https://docs.gcp.databricks.com/en/resources/ip-domain-region.html
-    default = "34.76.244.202" # Value for europe-west1 region
+  # For the value of the regional Hive Metastore IP, refer to the Databricks documentation:
+  # https://docs.gcp.databricks.com/en/resources/ip-domain-region.html
+  default = "34.76.244.202" # Value for europe-west1 region
 }
 
-// Users can connect to workspace only these list of IP's
-variable "ip_addresses" { 
-    # List of allowed IP addresses
-    type = list(string)
-    default = ["0.0.0.0/0"] # This is a default value allowing all IPs. Change it to restrict access.
+# Users can connect to workspace only from these IP addresses
+variable "ip_addresses" {
+  # List of allowed IP addresses
+  type    = list(string)
+  default = ["0.0.0.0/0"] # Default allows all IPs. Change to restrict access.
 }
+
 variable "relay_service_attachment" {
-    # Relay service attachment. regional values - https://docs.gcp.databricks.com/resources/supported-regions.html#psc
-    default = ""
-} 
-variable "workspace_service_attachment" { 
-    # Workspace service attachment. Regional values - https://docs.gcp.databricks.com/resources/supported-regions.html#psc
-    default = ""
-}
-variable "use_existing_pas" { 
-    # Flag to use an existing private access settings (this will be rarely the case)
-    default = false
-}
-variable "existing_pas_id" { 
-    # ID of the existing private access settings (only needed if use_existing_pas is true)
-    default = ""
+  # Relay service attachment. Regional values - https://docs.gcp.databricks.com/resources/supported-regions.html#psc
+  default = ""
 }
 
-
-###### CMEK VARIABLES ######
-variable "use_existing_cmek" { 
-    # Flag to use an existing CMEK
-    default = false
+variable "workspace_service_attachment" {
+  # Workspace service attachment. Regional values - https://docs.gcp.databricks.com/resources/supported-regions.html#psc
+  default = ""
 }
+
+variable "use_existing_pas" {
+  # Flag to use an existing private access settings (rare)
+  default = false
+}
+
+variable "existing_pas_id" {
+  # ID of the existing private access settings (only needed if use_existing_pas is true)
+  default = ""
+}
+
+##### CMEK VARIABLES #####
+variable "use_cmek" {
+  # Master flag: enable Customer-Managed Encryption Keys for the workspace
+  type        = bool
+  default     = false
+  description = "Set to true to use Customer-Managed Encryption Keys (CMEK) for workspace encryption."
+}
+
+variable "use_existing_cmek" {
+  # Flag to use an existing CMEK (only honored if use_cmek = true)
+  default = false
+}
+
 variable "key_name" {
-    # Key name for CMEK. only needed if use_existing_cmek is false
-    default = "sra-key"
-
-} 
-variable "keyring_name" {
-    # Keyring name for CMEK. only needed if use_existing_cmek is false
-    default = "sra-keyring"
-} 
-variable "cmek_resource_id" { 
-    # Resource ID for CMEK. only needed if use_existing_cmek is true
-    default = ""
+  # Key name for CMEK. Only used when creating a new CMEK.
+  default = "sra-key"
 }
 
+variable "keyring_name" {
+  # Keyring name for CMEK. Only used when creating a new CMEK.
+  default = "sra-keyring"
+}
+
+variable "cmek_resource_id" {
+  # Resource ID for CMEK. Only needed if use_existing_cmek is true.
+  default = ""
+}
+
+##### PSC / CONNECTIVITY VARIABLES #####
 variable "use_psc" {
-    # Flag to use Private Service Connect (PSC) for the workspace
-    default = false
+  # Flag to use Private Service Connect (PSC) for the workspace (backend PSC)
+  default = false
+}
+
+variable "use_frontend_psc" {
+  # Flag to enable frontend Private Service Connect
+  type        = bool
+  default     = false
+  description = "Set to true to enable frontend Private Service Connect (PSC) for the workspace."
 }
 
 variable "use_existing_databricks_vpc_eps" {
-    # Flag to use existing Databricks VPC Endpoints for PSC
-    default = false
+  # Flag to use existing Databricks VPC Endpoints for PSC
+  default = false
 }
-variable "existing_databricks_vpc_ep_workspace" {}
-variable "existing_databricks_vpc_ep_relay" {}
+
+variable "existing_databricks_vpc_ep_workspace" {
+  default = ""
+}
+
+variable "existing_databricks_vpc_ep_relay" {
+  default = ""
+}
+
+variable "existing_workspace_psc_endpoint_ip" {
+  type        = string
+  default     = ""
+  description = "IP address of the existing workspace PSC endpoint, used for DNS A-records. Only needed if use_existing_PSC_EP is true."
+}
+
+variable "existing_relay_psc_endpoint_ip" {
+  type        = string
+  default     = ""
+  description = "IP address of the existing relay (SCC tunnel) PSC endpoint, used for the tunnel DNS A-record. Only needed if use_existing_PSC_EP is true."
+}
+
+##### DNS VARIABLES #####
+variable "create_dns_zone" {
+  # If true, create a new private DNS zone for gcp.databricks.com and add A-records for the workspace.
+  # If false and existing_dns_zone_name is empty, no DNS resources are created (user manages DNS manually).
+  type        = bool
+  default     = false
+  description = "Create a private DNS zone for gcp.databricks.com. Takes precedence over existing_dns_zone_name."
+}
+
+variable "dns_zone_name" {
+  # Name for the private DNS zone (only used when create_dns_zone = true)
+  type        = string
+  default     = "databricks-private-zone"
+  description = "Name of the private DNS zone to create (only used when create_dns_zone = true)."
+}
+
+variable "existing_dns_zone_name" {
+  # Name of an existing private DNS zone to add A-records to.
+  # Leave empty if you use create_dns_zone or manage DNS manually.
+  type        = string
+  default     = ""
+  description = "Name of an existing private DNS zone to add A-records to."
+}
+
+##### ADMIN / USER VARIABLES #####
+variable "resource_owner" {
+  # Email address of the user to be granted admin access to the workspace
+  type        = string
+  default     = ""
+  description = "Email of the user to be granted admin access to the workspace."
+}
+
+variable "skip_user_lookup" {
+  # Skip user lookup data sources. Use for destroy operations when the resource_owner
+  # user may no longer exist in the account.
+  type        = bool
+  default     = false
+  description = "Skip user lookup data sources (useful for destroy operations)."
+}
 
 variable "admin_user_email" {
-    # Email address of the admin user to be added to the workspace
-    type = string
-    default = ""
-    description = "Email of the user to be granted admin access to the workspace"
+  # Legacy: email address of the admin user to be added to the workspace.
+  # Prefer resource_owner going forward.
+  type        = string
+  default     = ""
+  description = "Legacy admin user email. Prefer var.resource_owner."
 }
 
 variable "can_create_workspaces" {
-    # Flag to allow the service account to create workspaces
-    type = bool
-    default = true
-    description = "Flag to timeout the creation of the workspace"
+  # Flag indicating whether the service account has permission to create workspaces
+  type        = bool
+  default     = true
+  description = "Flag indicating the service account is ready to create workspaces."
 }
 
 variable "create_admin_user" {
-    # Flag to create the admin user in the workspace
-    type = bool
-    default = false
-    description = "Flag to create the admin user in the workspace"
+  # Legacy flag to create an admin user in the workspace
+  type        = bool
+  default     = false
+  description = "Legacy flag to create the admin user in the workspace."
 }
 
+##### METASTORE VARIABLES #####
 variable "regional_metastore_id" {
-    # Name of the regional Hive Metastore
-    default = ""
+  # ID of the regional Unity Catalog metastore
+  default = ""
 }
 
-variable "provision_regional_metastore"{
-    # Flag to provision a regional Hive Metastore
-    default = false
+variable "default_catalog_name" {
+  type        = string
+  default     = "default_catalog"
+  description = <<-EOT
+    Name of an existing catalog in the assigned metastore to set as the workspace's
+    default namespace. Defaults to "default_catalog" (the Databricks auto-created
+    catalog). Set to a different existing catalog name to point the workspace at it,
+    or set to "" to skip managing the default namespace and leave it at the
+    Databricks-assigned default. The module does NOT create the catalog — it must
+    already exist in the metastore.
+  EOT
+}
+
+variable "provision_regional_metastore" {
+  # Flag to provision a regional metastore
+  default = false
+}
+
+##### SERVERLESS / COMPUTE MODE #####
+variable "serverless_workspace_deployment" {
+  # Flag to deploy a serverless workspace (skips all network configuration).
+  type        = bool
+  default     = false
+  description = "Set to true to deploy a serverless workspace. When enabled, all VPC, PSC, and network resources are skipped."
 }

--- a/gcp/modules/workspace_deployment/variables.tf
+++ b/gcp/modules/workspace_deployment/variables.tf
@@ -35,14 +35,6 @@ variable "databricks_google_service_account_key" {
 }
 
 ##### NAMING VARIABLES #####
-variable "deployment_id" {
-  # Unique deployment ID used for naming. If empty, a random suffix is generated.
-  # When provided (e.g., a UUID from a backend), the first 8 characters are used.
-  type        = string
-  default     = ""
-  description = "Unique deployment ID. Leave empty to auto-generate a random 8-char suffix."
-}
-
 variable "resource_prefix" {
   # Prefix applied to resource names. Final format: <prefix>-<resource>-<deployment_suffix>
   type        = string
@@ -51,17 +43,15 @@ variable "resource_prefix" {
 }
 
 resource "random_string" "suffix" {
-  # Fallback suffix when var.deployment_id is not provided.
-  # Length kept at 6 to match the legacy behavior so existing deployments do
-  # not see the suffix regenerate on upgrade.
-  count   = var.deployment_id == "" ? 1 : 0
+  # Random suffix for resource naming. Length kept at 6 to match legacy behavior
+  # so existing deployments do not see the suffix regenerate on upgrade.
   special = false
   upper   = false
   length  = 6
 }
 
 locals {
-  deployment_suffix = var.deployment_id != "" ? substr(var.deployment_id, 0, 8) : random_string.suffix[0].result
+  deployment_suffix = random_string.suffix.result
 }
 
 ##### NETWORKING VARIABLES #####
@@ -130,6 +120,15 @@ variable "hive_metastore_ip" {
   # For the value of the regional Hive Metastore IP, refer to the Databricks documentation:
   # https://docs.gcp.databricks.com/en/resources/ip-domain-region.html
   default = "34.76.244.202" # Value for europe-west1 region
+}
+
+variable "databricks_control_plane_ips" {
+  # Regional control-plane IPs used in the egress firewall rule (non-PSC mode only).
+  # Look up the IPs for your region at:
+  # https://docs.databricks.com/gcp/en/resources/ip-domain-region
+  type        = list(string)
+  default     = []
+  description = "Databricks control-plane IPs for your region. Required when harden_network = true and use_psc = false. See https://docs.databricks.com/gcp/en/resources/ip-domain-region"
 }
 
 # Users can connect to workspace only from these IP addresses

--- a/gcp/modules/workspace_deployment/vpc-firewall.tf
+++ b/gcp/modules/workspace_deployment/vpc-firewall.tf
@@ -1,140 +1,158 @@
-resource "google_compute_firewall" "deny_egress" {
-  count = var.harden_network ? 1 : 0
-  depends_on = [
-    google_compute_network.dbx_private_vpc
-  ]
-  name                    = "deny-egress-${google_compute_network.dbx_private_vpc[0].name}"
-  direction               = "EGRESS"
-  priority                = 1100
-  destination_ranges      = ["0.0.0.0/0"]
-  source_ranges           = []
-  # allow                   = []
-  deny  {
-    protocol              = "all"
+# Data source for existing subnetwork, used when use_existing_vpc = true.
+data "google_compute_subnetwork" "existing" {
+  count   = (var.use_existing_vpc && !var.serverless_workspace_deployment) ? 1 : 0
+  name    = var.existing_subnet_name
+  region  = var.google_region
+  project = var.google_project
+}
+
+locals {
+  subnet_name = var.use_existing_vpc ? var.existing_subnet_name : try(google_compute_subnetwork.network-with-private-secondary-ip-ranges[0].name, "")
+  subnet_cidr = var.use_existing_vpc ? try(data.google_compute_subnetwork.existing[0].ip_cidr_range, "") : try(google_compute_subnetwork.network-with-private-secondary-ip-ranges[0].ip_cidr_range, "")
+}
+
+# Pre-create the intra-subnet ingress rule that Databricks would otherwise
+# auto-create on the workspace's VPC. By managing it here, Terraform owns
+# the rule's lifecycle end-to-end (no post-destroy cleanup needed).
+#
+# Skipped when use_existing_vpc = true — in bring-your-own-VPC mode the
+# caller is responsible for all GCP-side networking, including the subnet
+# ingress rule Databricks requires. Also skipped for serverless workspaces.
+resource "google_compute_firewall" "db_subnet_ingress" {
+  count = (var.use_existing_vpc || var.serverless_workspace_deployment) ? 0 : 1
+
+  name      = "db-${local.subnet_name}-ingress"
+  network   = google_compute_network.dbx_private_vpc[0].self_link
+  direction = "INGRESS"
+  priority  = 1000
+
+  source_ranges = [local.subnet_cidr]
+
+  allow {
+    protocol = "all"
   }
-  network                 = google_compute_network.dbx_private_vpc[0].self_link
+
+  depends_on = [
+    google_compute_network.dbx_private_vpc,
+    google_compute_subnetwork.network-with-private-secondary-ip-ranges,
+  ]
+}
+
+resource "google_compute_firewall" "deny_egress" {
+  count = (var.harden_network && !var.serverless_workspace_deployment) ? 1 : 0
+  depends_on = [
+    google_compute_network.dbx_private_vpc,
+  ]
+  name               = "deny-egress-${local.subnet_name}"
+  direction          = "EGRESS"
+  priority           = 1100
+  destination_ranges = ["0.0.0.0/0"]
+  source_ranges      = []
+  deny {
+    protocol = "all"
+  }
+  network = local.vpc_self_link
 }
 
 resource "google_compute_firewall" "from_gcp_healthcheck" {
+  count = (var.harden_network && !var.serverless_workspace_deployment) ? 1 : 0
   depends_on = [
-    google_compute_network.dbx_private_vpc
+    google_compute_network.dbx_private_vpc,
   ]
-  count = var.harden_network ? 1 : 0
-  name                    = "from-gcp-healthcheck-${google_compute_network.dbx_private_vpc[0].name}"
-  direction               = "INGRESS"
-  priority                = 1010
-  source_ranges           = ["130.211.0.0/22", "35.191.0.0/16"]
-  destination_ranges      = []
+  name               = "from-gcp-healthcheck-${local.subnet_name}"
+  direction          = "INGRESS"
+  priority           = 1010
+  source_ranges      = ["130.211.0.0/22", "35.191.0.0/16"]
+  destination_ranges = []
   allow {
-    protocol              = "tcp"
-    ports                 = ["80", "443"]
+    protocol = "tcp"
+    ports    = ["80", "443"]
   }
-  network                 = google_compute_network.dbx_private_vpc[0].self_link
+  network = local.vpc_self_link
 }
 
 resource "google_compute_firewall" "to_gcp_healthcheck" {
+  count = (var.harden_network && !var.serverless_workspace_deployment) ? 1 : 0
   depends_on = [
-    google_compute_network.dbx_private_vpc
+    google_compute_network.dbx_private_vpc,
   ]
-  count = var.harden_network ? 1 : 0
-  name                    = "to-gcp-healthcheck-${google_compute_network.dbx_private_vpc[0].name}"
-  direction               = "EGRESS"
-  priority                = 1000
-  destination_ranges      = ["130.211.0.0/22", "35.191.0.0/16"]
-  source_ranges           = []
+  name               = "to-gcp-healthcheck-${local.subnet_name}"
+  direction          = "EGRESS"
+  priority           = 1000
+  destination_ranges = ["130.211.0.0/22", "35.191.0.0/16"]
+  source_ranges      = []
   allow {
-    protocol              = "tcp"
-    ports                 = ["80", "443"]
+    protocol = "tcp"
+    ports    = ["80", "443"]
   }
-  network                 = google_compute_network.dbx_private_vpc[0].self_link
-}
-resource "google_compute_firewall" "to_gcp_psc" {
-  depends_on = [
-    google_compute_network.dbx_private_vpc
-  ]
-  count = (var.harden_network && var.use_psc) ? 1 : 0
-  name                    = "to-psc-ep-${google_compute_network.dbx_private_vpc[0].name}"
-  direction               = "EGRESS"
-  priority                = 1000
-  destination_ranges      = ["${google_compute_address.backend_pe_ip_address[0].address}/32", "${google_compute_address.frontend_pe_ip_address[0].address}/32"]
-  source_ranges           = []
-  allow {
-    protocol              = "tcp"
-    ports                 = ["443","8443-8463"]
-  }
-  network                 = google_compute_network.dbx_private_vpc[0].self_link
+  network = local.vpc_self_link
 }
 
+resource "google_compute_firewall" "to_gcp_psc" {
+  count = (var.harden_network && var.use_psc && !var.serverless_workspace_deployment) ? 1 : 0
+  depends_on = [
+    google_compute_network.dbx_private_vpc,
+  ]
+  name               = "to-psc-ep-${local.subnet_name}"
+  direction          = "EGRESS"
+  priority           = 1000
+  destination_ranges = ["${google_compute_address.backend_pe_ip_address[0].address}/32", "${google_compute_address.frontend_pe_ip_address[0].address}/32"]
+  source_ranges      = []
+  allow {
+    protocol = "tcp"
+    ports    = ["443", "8443-8463"]
+  }
+  network = local.vpc_self_link
+}
 
 resource "google_compute_firewall" "egress_intra_subnet" {
+  count = (var.harden_network && !var.serverless_workspace_deployment) ? 1 : 0
   depends_on = [
-    google_compute_network.dbx_private_vpc,google_compute_subnetwork.network-with-private-secondary-ip-ranges
+    google_compute_network.dbx_private_vpc,
+    google_compute_subnetwork.network-with-private-secondary-ip-ranges,
   ]
-  count                   = var.harden_network ? 1 : 0
-  name                    = "databricks-egress-intra-subnet"
-  direction               = "EGRESS"
-  priority                = 1000
-  destination_ranges      = [
-    google_compute_subnetwork.network-with-private-secondary-ip-ranges[0].ip_cidr_range
-  ]
-  source_ranges           = []
+  name               = "databricks-egress-intra-subnet-${local.deployment_suffix}"
+  direction          = "EGRESS"
+  priority           = 1000
+  destination_ranges = [local.subnet_cidr]
+  source_ranges      = []
   allow {
-    protocol              = "all"
+    protocol = "all"
   }
-  network                 = google_compute_network.dbx_private_vpc[0].self_link
+  network = local.vpc_self_link
 }
 
-
-
 resource "google_compute_firewall" "to_databricks_control_plane" {
+  count = (var.harden_network && !var.use_psc && !var.serverless_workspace_deployment) ? 1 : 0
   depends_on = [
-    google_compute_network.dbx_private_vpc
+    google_compute_network.dbx_private_vpc,
   ]
-  count = var.harden_network && !var.use_psc ? 1 : 0
-  name                    = "to-databricks-control-plane-${google_compute_network.dbx_private_vpc[0].name}"
-  direction               = "EGRESS"
-  priority                = 1000
-  destination_ranges      = [
-    # ADD REGIONAL IPS as listed here : https://docs.databricks.com/gcp/en/resources/ip-domain-region
-    # var.control_plane_ip_1,  # X.X.X.X/32
-    # var.control_plane_ip_2,  # X.X.X.X/28
-    # var.control_plane_ip_3,  # X.X.X.X/28
-    # var.control_plane_ip_4   # Y.Y.Y.Y/32
+  name      = "to-databricks-control-plane-${local.subnet_name}"
+  direction = "EGRESS"
+  priority  = 1000
+  destination_ranges = [
+    # ADD REGIONAL IPS as listed here: https://docs.databricks.com/gcp/en/resources/ip-domain-region
   ]
-  source_ranges           = []
+  source_ranges = []
   allow {
-    protocol              = "tcp"
-    ports                 = ["443", "8443-8451"]
+    protocol = "tcp"
+    ports    = ["443", "8443-8451"]
   }
-  network                 = google_compute_network.dbx_private_vpc[0].self_link
+  network = local.vpc_self_link
 }
 
 resource "google_compute_firewall" "to_google_apis" {
+  count = (var.harden_network && !var.serverless_workspace_deployment) ? 1 : 0
   depends_on = [
-    google_compute_network.dbx_private_vpc
+    google_compute_network.dbx_private_vpc,
   ]
-  count = var.harden_network ? 1 : 0
-  name                    = "to-google-apis-${google_compute_network.dbx_private_vpc[0].name}"
-  direction               = "EGRESS"
-  priority                = 1010
-  destination_ranges      = ["199.36.153.4/30"]
-  source_ranges           = []
+  name               = "to-google-apis-${local.subnet_name}"
+  direction          = "EGRESS"
+  priority           = 1010
+  destination_ranges = ["199.36.153.4/30"]
+  source_ranges      = []
   allow {
-    protocol              = "all"
+    protocol = "all"
   }
-  network                 = google_compute_network.dbx_private_vpc[0].self_link
+  network = local.vpc_self_link
 }
-# This is a legacy rule that is not used anymore, but kept for reference, and useful if UC is not used
-# resource "google_compute_firewall" "to_databricks_managed_hive" {
-#   count = var.harden_network ? 1 : 0
-#   name                    = "to-databricks-managed-hive-${google_compute_network.dbx_private_vpc.name}"
-#   direction               = "EGRESS"
-#   priority                = 1010
-#   destination_ranges      = []
-#   source_ranges           = [var.hive_metastore_ip]
-#   allow {
-#     protocol              = "tcp"
-#     ports                 = ["3306"]
-#   }
-#   network                 = google_compute_network.dbx_private_vpc[0] .self_link
-# }

--- a/gcp/modules/workspace_deployment/vpc-firewall.tf
+++ b/gcp/modules/workspace_deployment/vpc-firewall.tf
@@ -130,9 +130,7 @@ resource "google_compute_firewall" "to_databricks_control_plane" {
   name      = "to-databricks-control-plane-${local.subnet_name}"
   direction = "EGRESS"
   priority  = 1000
-  destination_ranges = [
-    # ADD REGIONAL IPS as listed here: https://docs.databricks.com/gcp/en/resources/ip-domain-region
-  ]
+  destination_ranges = var.databricks_control_plane_ips
   source_ranges = []
   allow {
     protocol = "tcp"

--- a/gcp/modules/workspace_deployment/vpc.tf
+++ b/gcp/modules/workspace_deployment/vpc.tf
@@ -1,63 +1,82 @@
+# Data source to look up the existing VPC when use_existing_vpc = true.
+# Used for DNS zone attachment and other references that need the network self_link.
+data "google_compute_network" "existing" {
+  count   = (var.use_existing_vpc && !var.serverless_workspace_deployment) ? 1 : 0
+  name    = var.existing_vpc_name
+  project = var.google_project
+}
+
+locals {
+  # Network identifiers resolved to either the created or existing VPC.
+  vpc_self_link = var.serverless_workspace_deployment ? "" : (
+    var.use_existing_vpc
+    ? data.google_compute_network.existing[0].self_link
+    : google_compute_network.dbx_private_vpc[0].self_link
+  )
+}
+
 resource "google_compute_network" "dbx_private_vpc" {
-  count = var.use_existing_vpc ? 0 : 1
+  count                   = (var.use_existing_vpc || var.serverless_workspace_deployment) ? 0 : 1
   project                 = var.google_project
   provider                = google
-  name                    = "databricks-workspace-vpc-${random_string.suffix.result}"
+  name                    = "${var.resource_prefix}-vpc-${local.deployment_suffix}"
   auto_create_subnetworks = false
 }
 
 resource "google_compute_subnetwork" "network-with-private-secondary-ip-ranges" {
-  count = var.use_existing_vpc ? 0 : 1
-  provider      = google
-  name          = "databricks-workspace-subnet-${random_string.suffix.result}"
-  ip_cidr_range = var.nodes_ip_cidr_range
-  region        = var.google_region
-  network       = google_compute_network.dbx_private_vpc[0].id
+  count                    = (var.use_existing_vpc || var.serverless_workspace_deployment) ? 0 : 1
+  provider                 = google
+  name                     = "${var.resource_prefix}-subnet-${local.deployment_suffix}"
+  ip_cidr_range            = var.nodes_ip_cidr_range
+  region                   = var.google_region
+  network                  = google_compute_network.dbx_private_vpc[0].id
   private_ip_google_access = true
 }
 
-
-
 resource "google_compute_router" "router" {
-  count = var.use_psc ? 0 : 1
-  name    = "my-router-${random_string.suffix.result}"
+  count   = (var.use_psc || var.use_existing_vpc || var.serverless_workspace_deployment) ? 0 : 1
+  name    = "${var.resource_prefix}-router-${local.deployment_suffix}"
   region  = google_compute_subnetwork.network-with-private-secondary-ip-ranges[0].region
   network = google_compute_network.dbx_private_vpc[0].id
 }
 
 resource "google_compute_router_nat" "nat" {
-  count = var.use_psc ? 0 : 1
-  name                               = "my-router-nat-${random_string.suffix.result}"
+  count                              = (var.use_psc || var.use_existing_vpc || var.serverless_workspace_deployment) ? 0 : 1
+  name                               = "${var.resource_prefix}-nat-${local.deployment_suffix}"
   router                             = google_compute_router.router[0].name
   region                             = google_compute_router.router[0].region
   nat_ip_allocate_option             = "AUTO_ONLY"
   source_subnetwork_ip_ranges_to_nat = "ALL_SUBNETWORKS_ALL_IP_RANGES"
 }
 
-
 resource "databricks_mws_networks" "network_config" {
-  
-  provider     = databricks.accounts
-  account_id   = var.databricks_account_id
-  network_name = "config-${var.google_region}-${random_string.suffix.result}"
+  count = var.serverless_workspace_deployment ? 0 : 1
+
+  provider   = databricks.accounts
+  account_id = var.databricks_account_id
+  # network_name has a 30-char limit. Drop the region from the name (it is
+  # still set on the resource via subnet_region below) to keep room for longer
+  # resource_prefix / deployment_suffix values.
+  network_name = "${var.resource_prefix}-net-${local.deployment_suffix}"
+
   gcp_network_info {
-    network_project_id    = var.google_project
-    vpc_id                = var.use_existing_vpc ? var.existing_vpc_name : google_compute_network.dbx_private_vpc[0].name
-    subnet_id             = var.use_existing_vpc ? var.existing_subnet_name : google_compute_subnetwork.network-with-private-secondary-ip-ranges[0].name
-    subnet_region         = var.google_region
+    network_project_id = var.google_project
+    vpc_id             = var.use_existing_vpc ? var.existing_vpc_name : google_compute_network.dbx_private_vpc[0].name
+    subnet_id          = var.use_existing_vpc ? var.existing_subnet_name : google_compute_subnetwork.network-with-private-secondary-ip-ranges[0].name
+    subnet_region      = var.google_region
   }
 
   depends_on = [
     google_compute_network.dbx_private_vpc,
     google_compute_subnetwork.network-with-private-secondary-ip-ranges,
-    google_compute_router_nat.nat
+    google_compute_router_nat.nat,
   ]
-  
+
   dynamic "vpc_endpoints" {
     for_each = var.use_psc ? [1] : []
     content {
-      dataplane_relay = var.use_existing_databricks_vpc_eps ? [var.existing_databricks_vpc_ep_relay] : [databricks_mws_vpc_endpoint.relay_vpce[0].vpc_endpoint_id]
-      rest_api        = var.use_existing_databricks_vpc_eps ? [var.existing_databricks_vpc_ep_workspace] : [databricks_mws_vpc_endpoint.backend_rest_vpce[0].vpc_endpoint_id]
+      dataplane_relay = var.use_existing_databricks_vpc_eps ? [var.existing_databricks_vpc_ep_relay] : [try(databricks_mws_vpc_endpoint.relay_vpce[0].vpc_endpoint_id, "")]
+      rest_api        = var.use_existing_databricks_vpc_eps ? [var.existing_databricks_vpc_ep_workspace] : [try(databricks_mws_vpc_endpoint.backend_rest_vpce[0].vpc_endpoint_id, "")]
     }
   }
 }

--- a/gcp/modules/workspace_deployment/workspace.tf
+++ b/gcp/modules/workspace_deployment/workspace.tf
@@ -1,12 +1,10 @@
-
-
 resource "databricks_mws_private_access_settings" "pas" {
- count = var.use_existing_pas ? 0 : 1
- provider       = databricks.accounts
- private_access_settings_name = "pas-${random_string.suffix.result}"
- region                       = var.google_region
- public_access_enabled        = true
- private_access_level         = "ACCOUNT"
+  count                        = (!var.use_existing_pas && (var.use_psc || var.use_frontend_psc)) ? 1 : 0
+  provider                     = databricks.accounts
+  private_access_settings_name = "${var.resource_prefix}-pas-${local.deployment_suffix}"
+  region                       = var.google_region
+  public_access_enabled        = true
+  private_access_level         = "ACCOUNT"
 }
 
 resource "databricks_mws_workspaces" "this" {
@@ -14,76 +12,61 @@ resource "databricks_mws_workspaces" "this" {
   account_id     = var.databricks_account_id
   workspace_name = var.workspace_name
   location       = var.google_region
-  cloud_resource_container {
-    gcp {
-      project_id = var.google_project
+
+  # Serverless workspaces set compute_mode explicitly and skip network config.
+  compute_mode = var.serverless_workspace_deployment ? "SERVERLESS" : null
+
+  # cloud_resource_container only applies to non-serverless workspaces.
+  dynamic "cloud_resource_container" {
+    for_each = var.serverless_workspace_deployment ? [] : [1]
+    content {
+      gcp {
+        project_id = var.google_project
+      }
     }
   }
-  private_access_settings_id = var.use_existing_pas? var.existing_pas_id:databricks_mws_private_access_settings.pas[0].private_access_settings_id
-  network_id = databricks_mws_networks.network_config.network_id
 
-  storage_customer_managed_key_id = var.use_existing_cmek ? var.cmek_resource_id : databricks_mws_customer_managed_keys.this[0].customer_managed_key_id
-  managed_services_customer_managed_key_id = var.use_existing_cmek ? var.cmek_resource_id : databricks_mws_customer_managed_keys.this[0].customer_managed_key_id
+  private_access_settings_id = (var.use_psc || var.use_frontend_psc) ? (
+    var.use_existing_pas ? var.existing_pas_id : databricks_mws_private_access_settings.pas[0].private_access_settings_id
+  ) : null
 
-  # this makes sure that the NAT is created for outbound traffic before creating the workspace
-  # not needed if the workspace uses backend PSC (recommended)
-  #depends_on = [ databricks_mws_customer_managed_keys.this]
+  network_id = var.serverless_workspace_deployment ? null : databricks_mws_networks.network_config[0].network_id
+
+  # CMEK keys:
+  # - storage CMEK: classic workspaces only (not applicable to serverless)
+  # - managed-services CMEK: both serverless and classic
+  storage_customer_managed_key_id = (var.use_cmek && !var.serverless_workspace_deployment) ? (
+    var.use_existing_cmek ? var.cmek_resource_id : databricks_mws_customer_managed_keys.this[0].customer_managed_key_id
+  ) : null
+  managed_services_customer_managed_key_id = var.use_cmek ? (
+    var.use_existing_cmek ? var.cmek_resource_id : databricks_mws_customer_managed_keys.this[0].customer_managed_key_id
+  ) : null
+
+  depends_on = [
+    google_compute_firewall.db_subnet_ingress,
+  ]
 }
 
-# Cleanup resource to handle Databricks-managed firewall rules
-# This prevents the "network in use by firewall rule" error during destroy
-resource "null_resource" "workspace_firewall_cleanup" {
-  # This resource is created after the workspace but destroyed before it
-  count = var.harden_network ? 1 : 0
+# Workspace-level hardening configuration.
+resource "databricks_workspace_conf" "this" {
+  count    = var.serverless_workspace_deployment ? 0 : 1
+  provider = databricks.workspace
+
+  custom_config = {
+    "enableIpAccessLists"    = "true"
+    "enableVerboseAuditLogs" = "true"
+    "enableDbfsFileBrowser"  = "false"
+    "maxTokenLifetimeDays"   = "90"
+  }
+
   depends_on = [databricks_mws_workspaces.this]
-  
-  triggers = {
-    workspace_id = databricks_mws_workspaces.this.workspace_id
-    network_name = google_compute_network.dbx_private_vpc[0].name
-    workspace_url = databricks_mws_workspaces.this.workspace_url
-  }
-  
-  provisioner "local-exec" {
-    when = destroy
-    command = <<-EOT
-      #!/bin/bash
-      set -e
-      
-      WORKSPACE_ID="${self.triggers.workspace_id}"
-      NETWORK_NAME="${self.triggers.network_name}"
-      
-      echo "🧹 Cleaning up Databricks-managed firewall rules for workspace $WORKSPACE_ID"
-      
-      # Find firewall rules created by Databricks for this workspace
-      FIREWALL_RULES=$(gcloud compute firewall-rules list \
-        --filter="name:databricks-$WORKSPACE_ID*" \
-        --format="value(name)" 2>/dev/null || true)
-      
-      if [ -n "$FIREWALL_RULES" ]; then
-        echo "📋 Found Databricks-managed firewall rules:"
-        echo "$FIREWALL_RULES"
-        
-        # Delete each firewall rule
-        while IFS= read -r rule; do
-          if [ -n "$rule" ]; then
-            echo "🗑️  Deleting firewall rule: $rule"
-            gcloud compute firewall-rules delete "$rule" --quiet 2>/dev/null || {
-              echo "⚠️  Warning: Could not delete firewall rule $rule (may already be deleted)"
-            }
-          fi
-        done <<< "$FIREWALL_RULES"
-        
-        echo "✅ Firewall cleanup completed"
-        sleep 3  # Allow time for changes to propagate
-      else
-        echo "ℹ️  No Databricks-managed firewall rules found for workspace $WORKSPACE_ID"
-      fi
-    EOT
-    
-    # Set environment for gcloud authentication
-    environment = {
-      GOOGLE_APPLICATION_CREDENTIALS = "/Users/aleksander.callebat/Documents/Databricks/fslakehouse-a08a713a0473.json"
-    }
-  }
 }
 
+# Account-level permission assignment APIs are not immediately available after
+# workspace creation. This short sleep (chained after workspace_conf) gives the
+# API time to become ready before admin assignments run.
+resource "time_sleep" "wait_for_workspace_apis" {
+  count           = var.serverless_workspace_deployment ? 0 : 1
+  create_duration = "5s"
+  depends_on      = [databricks_workspace_conf.this]
+}


### PR DESCRIPTION
- Uniform resource naming: ${resource_prefix}-<resource>-${deployment_suffix}
- Add serverless workspace support (compute_mode = SERVERLESS)
- Add flexible DNS for PSC: create zone + records, use existing zone, or manual
- Add tunnel.<region> DNS A-record for SCC relay (fixes cluster launch timeout)
- Add workspace hardening: IP access lists, verbose audit, DBFS browser off, 90-day tokens
- Add resource_owner admin assignment with skip_user_lookup for safe destroy
- Add use_cmek master flag; support creating fresh KMS keyring+key or reusing existing
- Replace deprecated default_catalog_name with databricks_default_namespace_setting
- Gate db_subnet_ingress firewall on !use_existing_vpc (BYO creates zero GCP resources)
- Decouple Databricks VPC endpoint registration from use_existing_vpc
- Fix network_name exceeding 30-char Databricks API limit
- Fix DNS record count depending on computed attributes (plan-time error)
- Comment out GCS backend in examples (default to local state)
- Bump Databricks provider to >=1.113.0
- Update end-to-end example: enable PSC + CMEK + hardened network
- Document googleapis.com DNS zone prerequisite for PSC + hardened network