### PR TITLE
Azure: Resolving provider workspace resolution post-creation; avoid storage account naming conflict

### DIFF
--- a/azure/tf/main.tf
+++ b/azure/tf/main.tf
@@ -117,7 +117,8 @@ module "hub_catalog" {
   ncc_id                = module.hub[0].ncc_id
   ncc_name              = module.hub[0].ncc_name
 
-  force_destroy = var.sat_force_destroy
+  storage_container_name = var.catalog_storage_container_name
+  force_destroy          = var.sat_force_destroy
 
   providers = {
     databricks.workspace = databricks.hub

--- a/azure/tf/modules/catalog/storage_account.tf
+++ b/azure/tf/modules/catalog/storage_account.tf
@@ -11,7 +11,7 @@ resource "azurerm_databricks_access_connector" "unity_catalog" {
 
 # Define an Azure Storage Account resource
 resource "azurerm_storage_account" "unity_catalog" {
-  name                            = local.storage_account_name
+  name                            = "ivanovichstoragespoke"#local.storage_account_name
   resource_group_name             = var.resource_group_name
   location                        = var.location
   account_tier                    = "Standard"

--- a/azure/tf/modules/catalog/storage_account.tf
+++ b/azure/tf/modules/catalog/storage_account.tf
@@ -11,7 +11,7 @@ resource "azurerm_databricks_access_connector" "unity_catalog" {
 
 # Define an Azure Storage Account resource
 resource "azurerm_storage_account" "unity_catalog" {
-  name                            = "ivanovichstoragespoke"#local.storage_account_name
+  name                            = local.storage_account_name
   resource_group_name             = var.resource_group_name
   location                        = var.location
   account_tier                    = "Standard"

--- a/azure/tf/modules/workspace/outputs.tf
+++ b/azure/tf/modules/workspace/outputs.tf
@@ -1,7 +1,8 @@
-# The value of the "workspace_url" property represents the URL of the Databricks workspace
+# Use the ARM workspace URL directly for consumers (e.g. databricks provider `host`). It matches the value in
+# null_resource.admin_wait triggers; avoid routing provider config through null_resource state, which can go stale.
 output "workspace_url" {
-  description = "The URL of the Databricks workspace, used to access the Databricks environment."
-  value       = null_resource.admin_wait.triggers.workspace_url
+  description = "HTTPS URL of the Databricks workspace (Azure workspace API host)."
+  value       = azurerm_databricks_workspace.this.workspace_url
 }
 
 output "workspace_id" {

--- a/azure/tf/providers.tf
+++ b/azure/tf/providers.tf
@@ -15,12 +15,14 @@ provider "databricks" {
 provider "databricks" {
   alias = "hub"
   host  = var.create_hub && length(module.webauth_workspace) > 0 ? module.webauth_workspace[0].workspace_url : "https://placeholder.azuredatabricks.net"
+  workspace_id = var.create_hub && length(module.webauth_workspace) > 0 ? module.webauth_workspace[0].workspace_id : null
 }
 
 # Spoke provider (required for creating a catalog in the spoke workspace)
 provider "databricks" {
   alias = "spoke"
   host  = module.spoke_workspace.workspace_url
+  workspace_id = module.spoke_workspace.workspace_id
 }
 
 # These blocks are not required by terraform, but they are here to silence TFLint warnings

--- a/azure/tf/providers.tf
+++ b/azure/tf/providers.tf
@@ -1,6 +1,7 @@
 provider "azurerm" {
   features {}
   subscription_id = var.subscription_id
+  tenant_id = var.tenant_id
 }
 
 provider "azapi" {

--- a/azure/tf/spoke.tf
+++ b/azure/tf/spoke.tf
@@ -4,7 +4,7 @@ locals {
   # Unity Catalog backing storage account: leading chars from sanitized resource_suffix + fixed-length random suffix.
   # Azure storage names allow at most 24 lowercase letters/digits; hyphens and other chars are stripped from the suffix first.
   catalog_storage_random_len       = 16
-  catalog_storage_sanitized_suffix = regexreplace(lower(var.resource_suffix), "[^a-z0-9]", "")
+  catalog_storage_sanitized_suffix = replace(lower(var.resource_suffix), "/[^a-z0-9]/", "")
   catalog_storage_prefix_max_len   = 24 - local.catalog_storage_random_len
   spoke_catalog_storage_account_name = substr(
     "${substr(local.catalog_storage_sanitized_suffix, 0, local.catalog_storage_prefix_max_len)}${random_string.catalog_storage_entropy.result}",

--- a/azure/tf/spoke.tf
+++ b/azure/tf/spoke.tf
@@ -100,7 +100,8 @@ module "spoke_catalog" {
   ncc_id                = module.spoke_workspace.ncc_id
   ncc_name              = module.spoke_workspace.ncc_name
 
-  force_destroy = var.catalog_force_destroy
+  storage_container_name = var.catalog_storage_container_name
+  force_destroy          = var.catalog_force_destroy
 
   providers = {
     databricks.workspace = databricks.spoke

--- a/azure/tf/spoke.tf
+++ b/azure/tf/spoke.tf
@@ -1,5 +1,24 @@
 locals {
   resource_group_name = var.create_workspace_resource_group ? azurerm_resource_group.spoke[0].name : var.existing_resource_group_name
+
+  # Unity Catalog backing storage account: leading chars from sanitized resource_suffix + fixed-length random suffix.
+  # Azure storage names allow at most 24 lowercase letters/digits; hyphens and other chars are stripped from the suffix first.
+  catalog_storage_random_len       = 16
+  catalog_storage_sanitized_suffix = regexreplace(lower(var.resource_suffix), "[^a-z0-9]", "")
+  catalog_storage_prefix_max_len   = 24 - local.catalog_storage_random_len
+  spoke_catalog_storage_account_name = substr(
+    "${substr(local.catalog_storage_sanitized_suffix, 0, local.catalog_storage_prefix_max_len)}${random_string.catalog_storage_entropy.result}",
+    0,
+    24,
+  )
+}
+
+resource "random_string" "catalog_storage_entropy" {
+  length  = local.catalog_storage_random_len
+  lower   = true
+  numeric = true
+  special = false
+  upper   = false
 }
 
 resource "azurerm_resource_group" "spoke" {
@@ -100,6 +119,7 @@ module "spoke_catalog" {
   ncc_id                = module.spoke_workspace.ncc_id
   ncc_name              = module.spoke_workspace.ncc_name
 
+  storage_account_name   = local.spoke_catalog_storage_account_name
   storage_container_name = var.catalog_storage_container_name
   force_destroy          = var.catalog_force_destroy
 

--- a/azure/tf/template.example.tfvars
+++ b/azure/tf/template.example.tfvars
@@ -10,7 +10,9 @@ workspace_vnet = {
   cidr = "10.0.4.0/22"
 }
 
-catalog_storage_container_name = "yourstoragecontainer"
+# catalog_storage_container_name = "unitycatalog"
+
+# UC root storage account name is derived from resource_suffix (hyphens stripped) + a 16-char random suffix (see spoke.tf).
 
 # Network mode: create_workspace_vnet defaults to true for SRA-managed network
 # create_workspace_vnet = true

--- a/azure/tf/template.example.tfvars
+++ b/azure/tf/template.example.tfvars
@@ -10,6 +10,8 @@ workspace_vnet = {
   cidr = "10.0.4.0/22"
 }
 
+catalog_storage_container_name = "yourstoragecontainer"
+
 # Network mode: create_workspace_vnet defaults to true for SRA-managed network
 # create_workspace_vnet = true
 

--- a/azure/tf/variables.tf
+++ b/azure/tf/variables.tf
@@ -3,6 +3,15 @@ variable "databricks_account_id" {
   description = "(Required) The Databricks account ID target for account-level operations"
 }
 
+variable "tenant_id" {
+  type = string
+}
+
+variable "subscription_id" {
+  type        = string
+  description = "(Required) Azure Subscription ID to deploy into"
+}
+
 variable "databricks_metastore_id" {
   type        = string
   default     = null
@@ -12,12 +21,6 @@ variable "databricks_metastore_id" {
     condition     = var.create_hub ? true : var.databricks_metastore_id != null
     error_message = "If var.create_hub is false, you must provide databricks_metastore_id"
   }
-}
-
-variable "catalog_storage_container_name" {
-  type        = string
-  default     = "unitycatalog"
-  description = "Blob container name inside the Unity Catalog backing storage account (module catalog azurerm_storage_container)."
 }
 
 variable "location" {
@@ -243,11 +246,6 @@ variable "tags" {
   default     = {}
 }
 
-variable "subscription_id" {
-  type        = string
-  description = "(Required) Azure Subscription ID to deploy into"
-}
-
 variable "sat_configuration" {
   type = object({
     enabled           = optional(bool, false)
@@ -286,4 +284,10 @@ variable "catalog_force_destroy" {
   type        = bool
   default     = false
   description = "Used to allow Terraform to force destroy the catalog. This is only used for testing SRA."
+}
+
+variable "catalog_storage_container_name" {
+  type        = string
+  default     = "unitycatalog"
+  description = "Blob container name inside the Unity Catalog backing storage account (module catalog azurerm_storage_container)."
 }

--- a/azure/tf/variables.tf
+++ b/azure/tf/variables.tf
@@ -14,6 +14,12 @@ variable "databricks_metastore_id" {
   }
 }
 
+variable "catalog_storage_container_name" {
+  type        = string
+  default     = "unitycatalog"
+  description = "Blob container name inside the Unity Catalog backing storage account (module catalog azurerm_storage_container)."
+}
+
 variable "location" {
   type        = string
   description = "(Required) The Azure region for the hub and spoke deployment"

--- a/azure/tf/versions.tf
+++ b/azure/tf/versions.tf
@@ -24,6 +24,10 @@ terraform {
       source  = "hashicorp/time"
       version = "~>0.13"
     }
+    random = {
+      source  = "hashicorp/random"
+      version = "~>3.0"
+    }
   }
   required_version = "~>1.11"
 }


### PR DESCRIPTION
Two primary changes for the Azure resources -- 

1. Add spoke suffix sanitization and random char padding to avoid disallowed charset for storage account name and reduce collision risk, since the name must be globally unique (not being able to set it doesn't make sense) and lowercase alphabet only.
2. Correcting the attribute reference in the providers section for workspaces (workspace_id, no id, since id is an ARM id, not a databricks one)
3. 2 also avoids the issue of having terraform attempt both Azure and Databricks auth methods post-workspace creation, as workspace_id is needed to disambiguate the resource for use with Azure Databricks unified identity.