### PR TITLE
Release/azure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,6 @@ gcp/modules/workspace_deployment/fslakehouse-9b0f57986dbf.json
 gcp/modules/service_account/*.json
 **/service_account/*.json
 .cursorignore
+
+# Claude Code personal/local settings
+.claude/settings.local.json

--- a/azure/README.md
+++ b/azure/README.md
@@ -63,6 +63,8 @@ In various .tf scripts, we have included direct links to the Databricks Terrafor
 allows Databricks customers to exercise more control over your network configures to comply with specific cloud security and governance standards that a
 customer's organization may require.
 
+- **Vnet Encryption**: [Azure VNET encryption](https://learn.microsoft.com/en-us/azure/virtual-network/virtual-network-encryption-overview) transparently encrypts traffic between supported VM SKUs on the spoke VNET. Off by default; opt in via `workspace_vnet.encryption_enabled = true`. Force-enabled when `workspace_security_compliance.compliance_security_profile_enabled = true`. The spoke VNET is created with `AllowUnencrypted` enforcement so workloads on SKUs that do not support encryption continue to function.
+
 - **Private Endpoints**: Using Private Link technology, a [private endpoint](https://learn.microsoft.com/en-us/azure/private-link/private-endpoint-overview) is a service that connects a customer's Vnet
 to Azure services without traversing public IP addresses.
 

--- a/azure/tf/customizations.tf
+++ b/azure/tf/customizations.tf
@@ -2,7 +2,7 @@ locals {
   create_sat_sp     = var.sat_configuration.enabled && var.sat_service_principal.client_id == "" && var.create_hub
   sat_client_id     = local.create_sat_sp ? azuread_service_principal.sat[0].client_id : var.sat_service_principal.client_id
   sat_client_secret = local.create_sat_sp ? azuread_service_principal_password.sat[0].value : var.sat_service_principal.client_secret
-  sat_workspace     = var.create_hub && length(module.webauth_workspace) > 0 ? module.webauth_workspace[0] : null
+  sat_workspace     = var.create_hub && length(module.serverless_workspace) > 0 ? module.serverless_workspace[0] : null
   sat_catalog       = var.sat_configuration.enabled && var.create_hub ? module.hub_catalog[0] : null
 }
 

--- a/azure/tf/customizations.tf
+++ b/azure/tf/customizations.tf
@@ -65,9 +65,8 @@ module "sat" {
 
   depends_on = [local.sat_catalog]
 
-  # Change the provider if needed
   providers = {
-    databricks = databricks.hub
+    databricks.workspace = databricks.sat
   }
 }
 
@@ -85,5 +84,7 @@ resource "databricks_permission_assignment" "sat_workspace_admin" {
   permissions  = ["ADMIN"]
   principal_id = module.sat[0].service_principal_id
 
-  provider = databricks.hub
+  provider_config {
+    workspace_id = local.sat_workspace.workspace_id
+  }
 }

--- a/azure/tf/main.tf
+++ b/azure/tf/main.tf
@@ -79,8 +79,11 @@ resource "databricks_disable_legacy_dbfs_setting" "webauth" {
     value = true
   }
 
+  provider_config {
+    workspace_id = module.webauth_workspace[0].workspace_id
+  }
+
   depends_on = [module.webauth_workspace]
-  provider   = databricks.hub
 }
 
 resource "databricks_disable_legacy_access_setting" "webauth" {
@@ -90,8 +93,11 @@ resource "databricks_disable_legacy_access_setting" "webauth" {
     value = true
   }
 
+  provider_config {
+    workspace_id = module.webauth_workspace[0].workspace_id
+  }
+
   depends_on = [module.webauth_workspace]
-  provider   = databricks.hub
 }
 
 module "hub_catalog" {
@@ -116,10 +122,7 @@ module "hub_catalog" {
   metastore_id          = module.hub[0].metastore_id
   ncc_id                = module.hub[0].ncc_id
   ncc_name              = module.hub[0].ncc_name
+  workspace_id          = module.webauth_workspace[0].workspace_id
 
   force_destroy = var.sat_force_destroy
-
-  providers = {
-    databricks.workspace = databricks.hub
-  }
 }

--- a/azure/tf/main.tf
+++ b/azure/tf/main.tf
@@ -43,7 +43,6 @@ module "serverless_workspace" {
   count  = var.create_hub ? 1 : 0
 
   provisioner_principal_id = data.azurerm_client_config.current.object_id
-  databricks_account_id    = var.databricks_account_id
   location                 = var.location
 
   private_endpoint_subnet_id = module.hub[0].network_configuration.private_endpoint_subnet_id
@@ -58,14 +57,12 @@ module "serverless_workspace" {
   # Account level settings
   # Note that these do not allow for supplying var.existing_... variables since the webauth workspace is only created when create_hub is true
   ncc_id            = module.hub[0].ncc_id
-  ncc_name          = module.hub[0].ncc_name
   network_policy_id = module.hub[0].hub_network_policy_id
   metastore_id      = module.hub[0].metastore_id
 
   # KMS Settings — serverless-only, so managed-disk CMK is not applicable.
   is_kms_enabled          = var.cmk_enabled
   managed_services_key_id = local.cmk_managed_services_key_id
-  key_vault_id            = local.cmk_keyvault_id
 
   depends_on = [module.hub]
 }

--- a/azure/tf/main.tf
+++ b/azure/tf/main.tf
@@ -37,19 +37,19 @@ module "hub" {
   resource_group_name      = azurerm_resource_group.hub[0].name
 }
 
-module "webauth_workspace" {
-  source = "./modules/workspace"
+module "serverless_workspace" {
+  source = "./modules/serverless_workspace"
   count  = var.create_hub ? 1 : 0
 
   provisioner_principal_id = data.azurerm_client_config.current.object_id
   databricks_account_id    = var.databricks_account_id
   location                 = var.location
 
-  network_configuration = module.hub[0].network_configuration
-  dns_zone_ids          = module.hub[0].dns_zone_ids
-  resource_group_name   = azurerm_resource_group.hub[0].name
-  resource_suffix       = module.hub[0].resource_suffix
-  tags                  = module.hub[0].tags
+  private_endpoint_subnet_id = module.hub[0].network_configuration.private_endpoint_subnet_id
+  dns_zone_ids               = module.hub[0].dns_zone_ids
+  resource_group_name        = azurerm_resource_group.hub[0].name
+  resource_suffix            = module.hub[0].resource_suffix
+  tags                       = module.hub[0].tags
   name_overrides = {
     "databricks_workspace" = "WEBAUTH_DO_NOT_DELETE_${upper(var.location)}"
   }
@@ -58,46 +58,15 @@ module "webauth_workspace" {
   # Note that these do not allow for supplying var.existing_... variables since the webauth workspace is only created when create_hub is true
   ncc_id            = module.hub[0].ncc_id
   ncc_name          = module.hub[0].ncc_name
-  network_policy_id = module.hub[0].network_policy_id
+  network_policy_id = module.hub[0].hub_network_policy_id
   metastore_id      = module.hub[0].metastore_id
 
-  # KMS Settings
+  # KMS Settings — serverless-only, so managed-disk CMK is not applicable.
   is_kms_enabled          = var.cmk_enabled
-  managed_disk_key_id     = local.cmk_managed_disk_key_id
   managed_services_key_id = local.cmk_managed_services_key_id
   key_vault_id            = local.cmk_keyvault_id
 
   depends_on = [module.hub]
-}
-
-#TODO: The below resources are temporary until the unified provider releases. At that time, they will be merged in to
-# the workspace module.
-resource "databricks_disable_legacy_dbfs_setting" "webauth" {
-  count = var.create_hub ? 1 : 0
-
-  disable_legacy_dbfs {
-    value = true
-  }
-
-  provider_config {
-    workspace_id = module.webauth_workspace[0].workspace_id
-  }
-
-  depends_on = [module.webauth_workspace]
-}
-
-resource "databricks_disable_legacy_access_setting" "webauth" {
-  count = var.create_hub ? 1 : 0
-
-  disable_legacy_access {
-    value = true
-  }
-
-  provider_config {
-    workspace_id = module.webauth_workspace[0].workspace_id
-  }
-
-  depends_on = [module.webauth_workspace]
 }
 
 module "hub_catalog" {
@@ -110,7 +79,7 @@ module "hub_catalog" {
   is_default_namespace = true
 
   # Azure/Network settings
-  dns_zone_ids        = module.webauth_workspace[0].dns_zone_ids
+  dns_zone_ids        = module.serverless_workspace[0].dns_zone_ids
   location            = var.location
   resource_group_name = azurerm_resource_group.hub[0].name
   resource_suffix     = "${local.sat_workspace.resource_suffix}sat"
@@ -122,7 +91,7 @@ module "hub_catalog" {
   metastore_id          = module.hub[0].metastore_id
   ncc_id                = module.hub[0].ncc_id
   ncc_name              = module.hub[0].ncc_name
-  workspace_id          = module.webauth_workspace[0].workspace_id
+  workspace_id          = module.serverless_workspace[0].workspace_id
 
   force_destroy = var.sat_force_destroy
 }

--- a/azure/tf/main.tf
+++ b/azure/tf/main.tf
@@ -35,6 +35,7 @@ module "hub" {
   is_unity_catalog_enabled = true
   tags                     = var.tags
   resource_group_name      = azurerm_resource_group.hub[0].name
+  force_destroy            = var.metastore_force_destroy
 }
 
 module "serverless_workspace" {

--- a/azure/tf/modules/catalog/.tflint.hcl
+++ b/azure/tf/modules/catalog/.tflint.hcl
@@ -1,0 +1,18 @@
+config {
+  variables = ["tags={\"example\"=\"value\"}"]
+}
+
+plugin "terraform" {
+  enabled = true
+}
+
+plugin "azurerm" {
+  enabled = true
+  version = "0.27.0"
+  source  = "github.com/terraform-linters/tflint-ruleset-azurerm"
+}
+
+rule "azurerm_resource_missing_tags" {
+  enabled = true
+  tags    = ["example"]
+}

--- a/azure/tf/modules/catalog/main.tf
+++ b/azure/tf/modules/catalog/main.tf
@@ -33,6 +33,10 @@ resource "databricks_external_location" "external_location" {
   provider_config {
     workspace_id = var.workspace_id
   }
+
+  lifecycle {
+    ignore_changes = [effective_file_event_queue]
+  }
 }
 
 resource "databricks_catalog" "catalog" {

--- a/azure/tf/modules/catalog/main.tf
+++ b/azure/tf/modules/catalog/main.tf
@@ -19,15 +19,20 @@ resource "databricks_storage_credential" "unity_catalog" {
     access_connector_id = azurerm_databricks_access_connector.unity_catalog.id
   }
 
-  provider = databricks.workspace
+  provider_config {
+    workspace_id = var.workspace_id
+  }
 }
+
 resource "databricks_external_location" "external_location" {
   credential_name = databricks_storage_credential.unity_catalog.name
   name            = azurerm_storage_account.unity_catalog.name
   force_destroy   = var.force_destroy
   url             = local.uc_abfss_url
 
-  provider = databricks.workspace
+  provider_config {
+    workspace_id = var.workspace_id
+  }
 }
 
 resource "databricks_catalog" "catalog" {
@@ -36,7 +41,9 @@ resource "databricks_catalog" "catalog" {
   force_destroy  = var.force_destroy
   isolation_mode = var.catalog_isolation_mode
 
-  provider = databricks.workspace
+  provider_config {
+    workspace_id = var.workspace_id
+  }
 }
 
 resource "databricks_default_namespace_setting" "this" {
@@ -46,5 +53,7 @@ resource "databricks_default_namespace_setting" "this" {
     value = databricks_catalog.catalog.name
   }
 
-  provider = databricks.workspace
+  provider_config {
+    workspace_id = var.workspace_id
+  }
 }

--- a/azure/tf/modules/catalog/variables.tf
+++ b/azure/tf/modules/catalog/variables.tf
@@ -61,6 +61,11 @@ variable "metastore_id" {
   description = "(Required) The ID of the metastore to associate with the Databricks workspace"
 }
 
+variable "workspace_id" {
+  type        = string
+  description = "(Required) Workspace ID of the Databricks workspace this catalog belongs to"
+}
+
 variable "catalog_name" {
   type        = string
   description = "(Required) Name of the catalog to create"

--- a/azure/tf/modules/catalog/versions.tf
+++ b/azure/tf/modules/catalog/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     databricks = {
       source  = "databricks/databricks"
-      version = ">=1.116"
+      version = ">=1.113.0"
     }
     azurerm = {
       source  = "hashicorp/azurerm"

--- a/azure/tf/modules/catalog/versions.tf
+++ b/azure/tf/modules/catalog/versions.tf
@@ -1,9 +1,8 @@
 terraform {
   required_providers {
     databricks = {
-      source                = "databricks/databricks"
-      version               = ">=1.0"
-      configuration_aliases = [databricks.workspace]
+      source  = "databricks/databricks"
+      version = ">=1.116"
     }
     azurerm = {
       source  = "hashicorp/azurerm"

--- a/azure/tf/modules/hub/locals.tf
+++ b/azure/tf/modules/hub/locals.tf
@@ -22,7 +22,7 @@ locals {
   # We use this to make sure that if we provision the 10th NCC in a region, that it does not cause subsequent terraform
   # plans/applies to fail due to the precondition on the NCC resource.
   ncc_name             = "ncc-${var.location}-${var.resource_suffix}"
-  current_ncc_count    = length([for k in data.databricks_mws_network_connectivity_configs.this.names : k if k != local.ncc_name])
+  current_ncc_count    = length([for k in (data.databricks_mws_network_connectivity_configs.this.names == null ? [] : data.databricks_mws_network_connectivity_configs.this.names) : k if k != local.ncc_name])
   ncc_region_limit     = 10
   title_cased_location = title(var.location)
 

--- a/azure/tf/modules/hub/locals.tf
+++ b/azure/tf/modules/hub/locals.tf
@@ -22,7 +22,7 @@ locals {
   # We use this to make sure that if we provision the 10th NCC in a region, that it does not cause subsequent terraform
   # plans/applies to fail due to the precondition on the NCC resource.
   ncc_name             = "ncc-${var.location}-${var.resource_suffix}"
-  current_ncc_count    = length([for k in (data.databricks_mws_network_connectivity_configs.this.names == null ? [] : data.databricks_mws_network_connectivity_configs.this.names) : k if k != local.ncc_name])
+  current_ncc_count    = length([for k in(data.databricks_mws_network_connectivity_configs.this.names == null ? [] : data.databricks_mws_network_connectivity_configs.this.names) : k if k != local.ncc_name])
   ncc_region_limit     = 10
   title_cased_location = title(var.location)
 

--- a/azure/tf/modules/hub/main.tf
+++ b/azure/tf/modules/hub/main.tf
@@ -20,6 +20,12 @@ module "hub_network" {
 
   virtual_network_peerings = var.virtual_network_peerings
 
+  # The hub workspace (WEBAUTH) is serverless-only and does not require subnets
+  workspace_subnets = {
+    create          = false
+    add_to_ip_group = false
+  }
+
   extra_subnets = {
     AzureFirewallSubnet = {
       name     = "AzureFirewallSubnet"

--- a/azure/tf/modules/hub/outputs.tf
+++ b/azure/tf/modules/hub/outputs.tf
@@ -83,3 +83,8 @@ output "network_cidr_blocks" {
   description = "CIDR allocations in hub network"
   value       = module.hub_network.network_cidr_blocks
 }
+
+output "firewall_policy_id" {
+  description = "Firewall policy ID"
+  value       = length(azurerm_firewall_policy.this) > 0 ? azurerm_firewall_policy.this[0].id : null
+}

--- a/azure/tf/modules/hub/unitycatalog.tf
+++ b/azure/tf/modules/hub/unitycatalog.tf
@@ -2,14 +2,7 @@
 resource "databricks_metastore" "this" {
   count = var.is_unity_catalog_enabled ? 1 : 0
 
-  name = "uc-metastore-${var.resource_suffix}"
-  # owner         = "uc admins"
+  name          = "uc-metastore-${var.resource_suffix}"
   region        = var.location
   force_destroy = var.force_destroy
-}
-
-resource "databricks_group" "this" {
-  count = var.is_unity_catalog_enabled ? 1 : 0
-
-  display_name = "${var.resource_suffix}-uc-owners"
 }

--- a/azure/tf/modules/hub/unitycatalog.tf
+++ b/azure/tf/modules/hub/unitycatalog.tf
@@ -5,7 +5,7 @@ resource "databricks_metastore" "this" {
   name = "uc-metastore-${var.resource_suffix}"
   # owner         = "uc admins"
   region        = var.location
-  force_destroy = true
+  force_destroy = var.force_destroy
 }
 
 resource "databricks_group" "this" {

--- a/azure/tf/modules/hub/variables.tf
+++ b/azure/tf/modules/hub/variables.tf
@@ -86,3 +86,9 @@ variable "virtual_network_peerings" {
   description = "(Optional) Map of virtual network peers to create from hub to spokes"
   default     = {}
 }
+
+variable "force_destroy" {
+  type        = bool
+  description = "(Optional) Run a force destroy on the metastore if it is not empty. ONLY WORKS IF SET WHEN METASTORE IS CREATED"
+  default     = false
+}

--- a/azure/tf/modules/sat/.tflint.hcl
+++ b/azure/tf/modules/sat/.tflint.hcl
@@ -1,0 +1,3 @@
+plugin "terraform" {
+  enabled = true
+}

--- a/azure/tf/modules/sat/main.tf
+++ b/azure/tf/modules/sat/main.tf
@@ -2,24 +2,40 @@ resource "databricks_secret" "client_secret" {
   key          = "client-secret"
   string_value = var.service_principal_client_secret
   scope        = module.sat.secret_scope_id
+
+  provider_config {
+    workspace_id = var.workspace_id
+  }
 }
 
 resource "databricks_secret" "subscription_id" {
   key          = "subscription-id"
   string_value = var.subscription_id
   scope        = module.sat.secret_scope_id
+
+  provider_config {
+    workspace_id = var.workspace_id
+  }
 }
 
 resource "databricks_secret" "tenant_id" {
   key          = "tenant-id"
   string_value = var.tenant_id
   scope        = module.sat.secret_scope_id
+
+  provider_config {
+    workspace_id = var.workspace_id
+  }
 }
 
 resource "databricks_secret" "client_id" {
   key          = "client-id"
   string_value = var.service_principal_client_id
   scope        = module.sat.secret_scope_id
+
+  provider_config {
+    workspace_id = var.workspace_id
+  }
 }
 
 data "databricks_group" "admins" {
@@ -40,6 +56,10 @@ resource "databricks_grant" "sat_sp_catalog" {
   principal  = databricks_service_principal.sp.application_id
   privileges = ["ALL_PRIVILEGES"]
   catalog    = var.catalog_name
+
+  provider_config {
+    workspace_id = var.workspace_id
+  }
 }
 
 module "sat" {
@@ -50,4 +70,8 @@ module "sat" {
   proxies              = var.proxies
   run_on_serverless    = var.run_on_serverless
   workspace_id         = var.workspace_id
+
+  providers = {
+    databricks = databricks.workspace
+  }
 }

--- a/azure/tf/modules/sat/versions.tf
+++ b/azure/tf/modules/sat/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     databricks = {
       source                = "databricks/databricks"
-      version               = ">=1.116"
+      version               = ">=1.113.0"
       configuration_aliases = [databricks.workspace]
     }
   }

--- a/azure/tf/modules/sat/versions.tf
+++ b/azure/tf/modules/sat/versions.tf
@@ -2,8 +2,9 @@ terraform {
   required_version = ">=1.0"
   required_providers {
     databricks = {
-      source  = "databricks/databricks"
-      version = ">=1.0"
+      source                = "databricks/databricks"
+      version               = ">=1.116"
+      configuration_aliases = [databricks.workspace]
     }
   }
 }

--- a/azure/tf/modules/self-approving-pe/.tflint.hcl
+++ b/azure/tf/modules/self-approving-pe/.tflint.hcl
@@ -1,0 +1,3 @@
+plugin "terraform" {
+  enabled = true
+}

--- a/azure/tf/modules/serverless_workspace/.tflint.hcl
+++ b/azure/tf/modules/serverless_workspace/.tflint.hcl
@@ -1,0 +1,18 @@
+config {
+  variables = ["tags={\"example\"=\"value\"}"]
+}
+
+plugin "terraform" {
+  enabled = true
+}
+
+plugin "azurerm" {
+  enabled = true
+  version = "0.27.0"
+  source  = "github.com/terraform-linters/tflint-ruleset-azurerm"
+}
+
+rule "azurerm_resource_missing_tags" {
+  enabled = true
+  tags    = ["example"]
+}

--- a/azure/tf/modules/serverless_workspace/README.md
+++ b/azure/tf/modules/serverless_workspace/README.md
@@ -1,0 +1,19 @@
+# serverless_workspace
+
+Provisions a serverless-only Azure Databricks workspace using the
+`Microsoft.Databricks/workspaces` ARM API (`computeMode = "Serverless"`) via the
+AzAPI provider.
+
+## Why this module exists
+
+The `azurerm_databricks_workspace` resource in the AzureRM provider does **not**
+support serverless workspaces — it cannot set `computeMode`, which is a
+create-only property of the ARM resource. This module is a temporary
+workaround built on AzAPI directly until that gap is closed in AzureRM.
+
+Tracking issue: [hashicorp/terraform-provider-azurerm#31218 — Support for
+serverless Azure Databricks workspaces](https://github.com/hashicorp/terraform-provider-azurerm/issues/31218).
+
+Once that lands, this module will be retired in favor of a normal
+`azurerm_databricks_workspace` configured with the equivalent serverless
+attribute.

--- a/azure/tf/modules/serverless_workspace/main.tf
+++ b/azure/tf/modules/serverless_workspace/main.tf
@@ -113,23 +113,3 @@ resource "databricks_workspace_network_option" "this" {
   network_policy_id = var.network_policy_id
   workspace_id      = azapi_resource.this.output.properties.workspaceId
 }
-
-resource "databricks_disable_legacy_dbfs_setting" "this" {
-  disable_legacy_dbfs {
-    value = true
-  }
-
-  provider_config {
-    workspace_id = azapi_resource.this.output.properties.workspaceId
-  }
-}
-
-resource "databricks_disable_legacy_access_setting" "this" {
-  disable_legacy_access {
-    value = true
-  }
-
-  provider_config {
-    workspace_id = azapi_resource.this.output.properties.workspaceId
-  }
-}

--- a/azure/tf/modules/serverless_workspace/main.tf
+++ b/azure/tf/modules/serverless_workspace/main.tf
@@ -1,0 +1,135 @@
+locals {
+  # Decompose the managed services key vault key URI (https://<vault>.vault.azure.net/keys/<name>/<version>)
+  # into the parts that the ARM API expects in the encryption block.
+  managed_services_key_parts = var.is_kms_enabled && var.managed_services_key_id != null ? regex(
+    "^(?P<vault_uri>https://[^/]+/)keys/(?P<name>[^/]+)/(?P<version>[^/]+)$",
+    var.managed_services_key_id
+  ) : { vault_uri = null, name = null, version = null }
+
+  csp_standards = var.enhanced_security_compliance.compliance_security_profile_standards
+  csp_enabled   = var.enhanced_security_compliance.compliance_security_profile_enabled
+
+  workspace_name = lookup(var.name_overrides, "databricks_workspace", module.naming.databricks_workspace.name)
+}
+
+module "naming" {
+  source  = "Azure/naming/azurerm"
+  version = "~>0.4"
+  suffix  = [var.resource_suffix]
+}
+
+# Serverless-only Databricks workspace via the Microsoft.Databricks ARM API. computeMode = "Serverless"
+# enforces this at the Azure resource level — classic cluster creation is rejected by the API. As a
+# consequence, custom_parameters (subnets/VNET/NAT/public IP/managed disk CMK/etc.), managedResourceGroupId,
+# defaultStorageFirewall, accessConnector, and requiredNsgRules are all forbidden and intentionally omitted.
+resource "azapi_resource" "this" {
+  type      = "Microsoft.Databricks/workspaces@2026-01-01"
+  name      = local.workspace_name
+  parent_id = "/subscriptions/${data.azurerm_client_config.current.subscription_id}/resourceGroups/${var.resource_group_name}"
+  location  = var.location
+  tags      = var.tags
+
+  body = {
+    sku = {
+      name = "premium"
+    }
+    properties = {
+      computeMode = "Serverless"
+
+      publicNetworkAccess = var.is_frontend_private_link_enabled ? "Disabled" : "Enabled"
+
+      encryption = var.is_kms_enabled ? {
+        entities = {
+          managedServices = {
+            keySource = "Microsoft.Keyvault"
+            keyVaultProperties = {
+              keyName     = local.managed_services_key_parts.name
+              keyVaultUri = local.managed_services_key_parts.vault_uri
+              keyVersion  = local.managed_services_key_parts.version
+            }
+          }
+        }
+      } : null
+
+      enhancedSecurityCompliance = {
+        automaticClusterUpdate = {
+          value = var.enhanced_security_compliance.automatic_cluster_update_enabled == true ? "Enabled" : "Disabled"
+        }
+        complianceSecurityProfile = {
+          value               = local.csp_enabled == true ? "Enabled" : "Disabled"
+          complianceStandards = local.csp_standards == null ? [] : local.csp_standards
+        }
+        enhancedSecurityMonitoring = {
+          value = var.enhanced_security_compliance.enhanced_security_monitoring_enabled == true ? "Enabled" : "Disabled"
+        }
+      }
+    }
+  }
+
+  ignore_null_property   = true
+  response_export_values = ["properties.workspaceUrl", "properties.workspaceId"]
+}
+
+data "azurerm_client_config" "current" {}
+
+resource "time_sleep" "workspace_wait" {
+  triggers = {
+    workspace_id = azapi_resource.this.output.properties.workspaceId
+  }
+  create_duration  = "10s"
+  destroy_duration = "10s"
+}
+
+# Grant Contributor on the workspace to the provisioner so downstream workspace-aliased providers
+# (hub_catalog, SAT) can authenticate.
+resource "azurerm_role_assignment" "contributor" {
+  role_definition_name = "contributor"
+  scope                = azapi_resource.this.id
+  principal_id         = var.provisioner_principal_id
+  description          = "This is granted by the Databricks SRA Terraform module. It grants workspace admin to the provisioner principal of the workspace."
+}
+
+# Gates the workspace_url output until role assignment + metastore assignment exist, so downstream
+# provider aliases can rely on the URL being usable.
+resource "null_resource" "admin_wait" {
+  triggers = {
+    workspace_url = azapi_resource.this.output.properties.workspaceUrl
+    workspace_id  = azurerm_role_assignment.contributor.scope
+    metastore_id  = databricks_metastore_assignment.this.metastore_id
+  }
+}
+
+resource "databricks_metastore_assignment" "this" {
+  workspace_id = azapi_resource.this.output.properties.workspaceId
+  metastore_id = var.metastore_id
+}
+
+resource "databricks_mws_ncc_binding" "this" {
+  network_connectivity_config_id = var.ncc_id
+  workspace_id                   = azapi_resource.this.output.properties.workspaceId
+}
+
+resource "databricks_workspace_network_option" "this" {
+  network_policy_id = var.network_policy_id
+  workspace_id      = azapi_resource.this.output.properties.workspaceId
+}
+
+resource "databricks_disable_legacy_dbfs_setting" "this" {
+  disable_legacy_dbfs {
+    value = true
+  }
+
+  provider_config {
+    workspace_id = azapi_resource.this.output.properties.workspaceId
+  }
+}
+
+resource "databricks_disable_legacy_access_setting" "this" {
+  disable_legacy_access {
+    value = true
+  }
+
+  provider_config {
+    workspace_id = azapi_resource.this.output.properties.workspaceId
+  }
+}

--- a/azure/tf/modules/serverless_workspace/outputs.tf
+++ b/azure/tf/modules/serverless_workspace/outputs.tf
@@ -1,0 +1,39 @@
+output "workspace_url" {
+  description = "The URL of the Databricks workspace. Gated behind the admin role assignment + metastore assignment so downstream provider aliases can rely on it."
+  value       = null_resource.admin_wait.triggers.workspace_url
+}
+
+output "workspace_id" {
+  value       = azapi_resource.this.output.properties.workspaceId
+  description = "Workspace ID of the created workspace, according to the Databricks account console"
+}
+
+output "id" {
+  value       = azapi_resource.this.id
+  description = "Azure ID of the created workspace"
+}
+
+output "dns_zone_ids" {
+  description = "Private DNS Zone IDs (passthrough from input) for downstream consumers"
+  value       = var.dns_zone_ids
+}
+
+output "resource_suffix" {
+  description = "Resource suffix to use for naming downstream resources"
+  value       = var.resource_suffix
+}
+
+output "tags" {
+  description = "Tags applied to resources in this module"
+  value       = var.tags
+}
+
+output "webauth_private_endpoint_id" {
+  description = "ID of the webauth (browser_authentication) private endpoint"
+  value       = azurerm_private_endpoint.webauth.id
+}
+
+output "resource_group_name" {
+  description = "Name of the resource group hosting this workspace"
+  value       = var.resource_group_name
+}

--- a/azure/tf/modules/serverless_workspace/variables.tf
+++ b/azure/tf/modules/serverless_workspace/variables.tf
@@ -1,0 +1,107 @@
+variable "resource_group_name" {
+  type        = string
+  description = "(Required) The name of the resource group to deploy the workspace to"
+}
+
+variable "location" {
+  type        = string
+  description = "(Required) The location for the workspace deployment"
+}
+
+variable "resource_suffix" {
+  type        = string
+  description = "(Required) Naming resource_suffix for resources"
+}
+
+variable "tags" {
+  type        = map(string)
+  description = "(Optional) Map of tags to attach to resources"
+  default     = {}
+}
+
+variable "name_overrides" {
+  type        = map(string)
+  description = "(Optional) Override names for resources. Keys should match naming module outputs (e.g., 'databricks_workspace', 'private_endpoint')."
+  nullable    = false
+  default     = {}
+}
+
+variable "private_endpoint_subnet_id" {
+  type        = string
+  description = "(Required) Subnet ID where the webauth private endpoint will be created"
+}
+
+variable "dns_zone_ids" {
+  type = object({
+    backend = string
+    dfs     = string
+    blob    = string
+  })
+  description = "Private DNS zone IDs. Only backend is used by this module; dfs and blob are passed through as outputs for downstream consumers (e.g., hub_catalog)."
+}
+
+variable "provisioner_principal_id" {
+  type        = string
+  description = "Principal ID of the user/SP running this terraform; granted Contributor on the workspace"
+}
+
+variable "databricks_account_id" {
+  type        = string
+  description = "Databricks account ID"
+}
+
+variable "metastore_id" {
+  type        = string
+  description = "(Required) The ID of the metastore to associate with the Databricks workspace"
+}
+
+variable "ncc_id" {
+  type        = string
+  description = "ID of the NCC to bind to this workspace (serverless egress)"
+}
+
+variable "ncc_name" {
+  type        = string
+  description = "Name of the NCC bound to this workspace"
+}
+
+variable "network_policy_id" {
+  type        = string
+  description = "ID of the account network policy to assign to this workspace"
+}
+
+variable "is_kms_enabled" {
+  type        = bool
+  description = "(Optional) Enable customer-managed key encryption for the managed services key. Managed disk CMK is not applicable to a serverless-only workspace."
+  default     = false
+}
+
+variable "key_vault_id" {
+  type        = string
+  description = "(Optional) ID of the Azure Key Vault containing the managed services CMK. Required when is_kms_enabled is true."
+  default     = null
+}
+
+variable "managed_services_key_id" {
+  type        = string
+  description = "(Optional) The key for managed services encryption. Required when is_kms_enabled is true."
+  default     = null
+}
+
+variable "is_frontend_private_link_enabled" {
+  type        = bool
+  description = "(Optional) When true, disables public network access to the workspace (frontend private link only)."
+  default     = false
+}
+
+variable "enhanced_security_compliance" {
+  description = "(Optional) Enhanced security compliance configuration."
+  type = object({
+    automatic_cluster_update_enabled      = optional(bool, null)
+    compliance_security_profile_enabled   = optional(bool, null)
+    compliance_security_profile_standards = optional(list(string), null)
+    enhanced_security_monitoring_enabled  = optional(bool, null)
+  })
+  nullable = false
+  default  = {}
+}

--- a/azure/tf/modules/serverless_workspace/variables.tf
+++ b/azure/tf/modules/serverless_workspace/variables.tf
@@ -45,11 +45,6 @@ variable "provisioner_principal_id" {
   description = "Principal ID of the user/SP running this terraform; granted Contributor on the workspace"
 }
 
-variable "databricks_account_id" {
-  type        = string
-  description = "Databricks account ID"
-}
-
 variable "metastore_id" {
   type        = string
   description = "(Required) The ID of the metastore to associate with the Databricks workspace"
@@ -58,11 +53,6 @@ variable "metastore_id" {
 variable "ncc_id" {
   type        = string
   description = "ID of the NCC to bind to this workspace (serverless egress)"
-}
-
-variable "ncc_name" {
-  type        = string
-  description = "Name of the NCC bound to this workspace"
 }
 
 variable "network_policy_id" {
@@ -74,12 +64,6 @@ variable "is_kms_enabled" {
   type        = bool
   description = "(Optional) Enable customer-managed key encryption for the managed services key. Managed disk CMK is not applicable to a serverless-only workspace."
   default     = false
-}
-
-variable "key_vault_id" {
-  type        = string
-  description = "(Optional) ID of the Azure Key Vault containing the managed services CMK. Required when is_kms_enabled is true."
-  default     = null
 }
 
 variable "managed_services_key_id" {

--- a/azure/tf/modules/serverless_workspace/versions.tf
+++ b/azure/tf/modules/serverless_workspace/versions.tf
@@ -1,0 +1,29 @@
+terraform {
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = ">=3.65.0"
+    }
+    azapi = {
+      source  = "Azure/azapi"
+      version = ">=2.0"
+    }
+    databricks = {
+      source  = "databricks/databricks"
+      version = ">=1.24.1"
+    }
+    null = {
+      source  = "hashicorp/null"
+      version = ">=3.0"
+    }
+    time = {
+      source  = "hashicorp/time"
+      version = ">=0.13"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = ">=3.0"
+    }
+  }
+  required_version = ">=1.9.8"
+}

--- a/azure/tf/modules/serverless_workspace/versions.tf
+++ b/azure/tf/modules/serverless_workspace/versions.tf
@@ -20,10 +20,6 @@ terraform {
       source  = "hashicorp/time"
       version = ">=0.13"
     }
-    random = {
-      source  = "hashicorp/random"
-      version = ">=3.0"
-    }
   }
   required_version = ">=1.9.8"
 }

--- a/azure/tf/modules/serverless_workspace/webauth_privatelink.tf
+++ b/azure/tf/modules/serverless_workspace/webauth_privatelink.tf
@@ -1,0 +1,20 @@
+resource "azurerm_private_endpoint" "webauth" {
+  name                = "${lookup(var.name_overrides, "private_endpoint", module.naming.private_endpoint.name_unique)}-webauth"
+  location            = var.location
+  resource_group_name = var.resource_group_name
+  subnet_id           = var.private_endpoint_subnet_id
+
+  private_service_connection {
+    name                           = "ple-${var.resource_suffix}-webauth"
+    private_connection_resource_id = azapi_resource.this.id
+    is_manual_connection           = false
+    subresource_names              = ["browser_authentication"]
+  }
+
+  private_dns_zone_group {
+    name                 = "private-dns-zone-webauth"
+    private_dns_zone_ids = [var.dns_zone_ids.backend]
+  }
+
+  tags = var.tags
+}

--- a/azure/tf/modules/virtual_network/main.tf
+++ b/azure/tf/modules/virtual_network/main.tf
@@ -1,6 +1,6 @@
 # Define subnets using cidrsubnet function
 locals {
-  workspace_subnets = toset(["container", "host"])
+  workspace_subnets = var.workspace_subnets.create ? toset(["container", "host"]) : toset([])
   subnets = concat(
     var.workspace_subnets.create ? [
       for subnet in local.workspace_subnets :

--- a/azure/tf/modules/virtual_network/main.tf
+++ b/azure/tf/modules/virtual_network/main.tf
@@ -40,6 +40,13 @@ resource "azurerm_virtual_network" "this" {
   resource_group_name = var.resource_group_name
   address_space       = [var.vnet_cidr]
 
+  dynamic "encryption" {
+    for_each = var.encryption_enabled ? [1] : []
+    content {
+      enforcement = "AllowUnencrypted"
+    }
+  }
+
   tags = var.tags
 }
 

--- a/azure/tf/modules/virtual_network/outputs.tf
+++ b/azure/tf/modules/virtual_network/outputs.tf
@@ -56,23 +56,23 @@ output "vnet_id" {
 
 output "public_subnet_network_security_group_association_id" {
   description = "ID of the public subnet network security group association"
-  value       = azurerm_subnet_network_security_group_association.workspace_subnets["host"].id
+  value       = try(azurerm_subnet_network_security_group_association.workspace_subnets["host"].id, null)
 }
 
 output "private_subnet_network_security_group_association_id" {
   description = "ID of the private subnet network security group association"
-  value       = azurerm_subnet_network_security_group_association.workspace_subnets["container"].id
+  value       = try(azurerm_subnet_network_security_group_association.workspace_subnets["container"].id, null)
 }
 
 output "network_configuration" {
   description = "Network configuration for use with the workspace module"
   value = {
     virtual_network_id                                   = azurerm_virtual_network.this.id
-    private_subnet_id                                    = azurerm_subnet.workspace_subnets["container"].id
-    public_subnet_id                                     = azurerm_subnet.workspace_subnets["host"].id
+    private_subnet_id                                    = try(azurerm_subnet.workspace_subnets["container"].id, null)
+    public_subnet_id                                     = try(azurerm_subnet.workspace_subnets["host"].id, null)
     private_endpoint_subnet_id                           = azurerm_subnet.privatelink.id
-    private_subnet_network_security_group_association_id = azurerm_subnet_network_security_group_association.workspace_subnets["container"].id
-    public_subnet_network_security_group_association_id  = azurerm_subnet_network_security_group_association.workspace_subnets["host"].id
+    private_subnet_network_security_group_association_id = try(azurerm_subnet_network_security_group_association.workspace_subnets["container"].id, null)
+    public_subnet_network_security_group_association_id  = try(azurerm_subnet_network_security_group_association.workspace_subnets["host"].id, null)
   }
 }
 

--- a/azure/tf/modules/virtual_network/variables.tf
+++ b/azure/tf/modules/virtual_network/variables.tf
@@ -82,6 +82,12 @@ variable "tags" {
   default     = {}
 }
 
+variable "encryption_enabled" {
+  type        = bool
+  description = "(Optional) Whether to enable VNET encryption (AllowUnencrypted enforcement) on the spoke virtual network."
+  default     = false
+}
+
 variable "virtual_network_peerings" {
   type = map(object({
     name                      = optional(string, "")

--- a/azure/tf/modules/workspace/main.tf
+++ b/azure/tf/modules/workspace/main.tf
@@ -134,3 +134,23 @@ resource "databricks_workspace_network_option" "this" {
   network_policy_id = var.network_policy_id
   workspace_id      = azurerm_databricks_workspace.this.workspace_id
 }
+
+resource "databricks_disable_legacy_dbfs_setting" "this" {
+  disable_legacy_dbfs {
+    value = true
+  }
+
+  provider_config {
+    workspace_id = azurerm_databricks_workspace.this.workspace_id
+  }
+}
+
+resource "databricks_disable_legacy_access_setting" "this" {
+  disable_legacy_access {
+    value = true
+  }
+
+  provider_config {
+    workspace_id = azurerm_databricks_workspace.this.workspace_id
+  }
+}

--- a/azure/tf/modules/workspace/main.tf
+++ b/azure/tf/modules/workspace/main.tf
@@ -135,16 +135,6 @@ resource "databricks_workspace_network_option" "this" {
   workspace_id      = azurerm_databricks_workspace.this.workspace_id
 }
 
-resource "databricks_disable_legacy_dbfs_setting" "this" {
-  disable_legacy_dbfs {
-    value = true
-  }
-
-  provider_config {
-    workspace_id = azurerm_databricks_workspace.this.workspace_id
-  }
-}
-
 resource "databricks_disable_legacy_access_setting" "this" {
   disable_legacy_access {
     value = true

--- a/azure/tf/modules/workspace/main.tf
+++ b/azure/tf/modules/workspace/main.tf
@@ -3,15 +3,6 @@ locals {
   managed_rg_name = join("", [module.naming.resource_group.name_unique, "adbmanaged"])
   public_subnet   = provider::azurerm::parse_resource_id(var.network_configuration.public_subnet_id)
   private_subnet  = provider::azurerm::parse_resource_id(var.network_configuration.private_subnet_id)
-  csp_update_body = {
-    properties = {
-      enhancedSecurityCompliance = {
-        complianceSecurityProfile = {
-          complianceStandards = var.enhanced_security_compliance.compliance_security_profile_standards
-        }
-      }
-    }
-  }
 }
 
 module "naming" {
@@ -47,7 +38,7 @@ resource "azurerm_databricks_workspace" "this" {
   enhanced_security_compliance {
     automatic_cluster_update_enabled      = var.enhanced_security_compliance.automatic_cluster_update_enabled
     compliance_security_profile_enabled   = var.enhanced_security_compliance.compliance_security_profile_enabled
-    compliance_security_profile_standards = [] # Note that this is always an empty list, as a separate azapi resource manages this
+    compliance_security_profile_standards = var.enhanced_security_compliance.compliance_security_profile_standards
     enhanced_security_monitoring_enabled  = var.enhanced_security_compliance.enhanced_security_monitoring_enabled
   }
 
@@ -61,18 +52,7 @@ resource "azurerm_databricks_workspace" "this" {
     private_subnet_network_security_group_association_id = var.network_configuration.private_subnet_network_security_group_association_id
   }
 
-  lifecycle {
-    ignore_changes = [enhanced_security_compliance[0].compliance_security_profile_standards]
-  }
-
   tags = var.tags
-}
-
-resource "azapi_update_resource" "this" {
-  count       = var.enhanced_security_compliance.compliance_security_profile_standards == null ? 0 : 1
-  type        = "Microsoft.Databricks/workspaces@2025-03-01-preview"
-  resource_id = azurerm_databricks_workspace.this.id
-  body        = local.csp_update_body
 }
 
 # Wait for 10 seconds after workspace creation to allow for APIs to become available

--- a/azure/tf/modules/workspace/versions.tf
+++ b/azure/tf/modules/workspace/versions.tf
@@ -4,10 +4,6 @@ terraform {
       source  = "hashicorp/azurerm"
       version = ">=3.65.0"
     }
-    azapi = {
-      source  = "Azure/azapi"
-      version = ">=2.0"
-    }
     databricks = {
       source  = "databricks/databricks"
       version = ">=1.24.1"

--- a/azure/tf/outputs.tf
+++ b/azure/tf/outputs.tf
@@ -26,3 +26,18 @@ output "spoke_workspace_catalog" {
   description = "Name of the catalog created for the spoke workspace"
   value       = module.spoke_catalog.catalog_name
 }
+
+output "spoke_workspace_network_cidr_blocks" {
+  description = "CIDR blocks of the spoke workspace"
+  value       = length(module.spoke_network) > 0 ? module.spoke_network[0].network_cidr_blocks : {}
+}
+
+output "spoke_firewall_rule_collection_group_id" {
+  description = "ID of the spoke firewall rule collection group, if created"
+  value       = length(azurerm_firewall_policy_rule_collection_group.spoke) > 0 ? azurerm_firewall_policy_rule_collection_group.spoke[0].id : null
+}
+
+output "spoke_network_policy_id" {
+  description = "ID of the spoke network policy, if created"
+  value       = length(databricks_account_network_policy.spoke) > 0 ? databricks_account_network_policy.spoke[0].network_policy_id : null
+}

--- a/azure/tf/outputs.tf
+++ b/azure/tf/outputs.tf
@@ -10,7 +10,7 @@ output "hub_resource_group_name" {
 
 output "hub_workspace_info" {
   description = "URLs for the one (or more) deployed Databricks Workspaces"
-  value       = var.create_hub ? [azurerm_resource_group.hub[0].name, module.webauth_workspace[0].workspace_url] : null
+  value       = var.create_hub ? [azurerm_resource_group.hub[0].name, module.serverless_workspace[0].workspace_url] : null
 }
 
 output "spoke_workspace_info" {

--- a/azure/tf/providers.tf
+++ b/azure/tf/providers.tf
@@ -16,7 +16,7 @@ provider "databricks" {
 # (databricks-industry-solutions/security-analysis-tool).
 provider "databricks" {
   alias = "sat"
-  host  = var.create_hub && length(module.webauth_workspace) > 0 ? module.webauth_workspace[0].workspace_url : "https://placeholder.azuredatabricks.net"
+  host  = var.create_hub && length(module.serverless_workspace) > 0 ? module.serverless_workspace[0].workspace_url : "https://placeholder.azuredatabricks.net"
 }
 
 # These blocks are not required by terraform, but they are here to silence TFLint warnings

--- a/azure/tf/providers.tf
+++ b/azure/tf/providers.tf
@@ -12,15 +12,11 @@ provider "databricks" {
   account_id = var.databricks_account_id
 }
 
+# Used only to pass a workspace-level provider to the external SAT submodule
+# (databricks-industry-solutions/security-analysis-tool).
 provider "databricks" {
-  alias = "hub"
+  alias = "sat"
   host  = var.create_hub && length(module.webauth_workspace) > 0 ? module.webauth_workspace[0].workspace_url : "https://placeholder.azuredatabricks.net"
-}
-
-# Spoke provider (required for creating a catalog in the spoke workspace)
-provider "databricks" {
-  alias = "spoke"
-  host  = module.spoke_workspace.workspace_url
 }
 
 # These blocks are not required by terraform, but they are here to silence TFLint warnings

--- a/azure/tf/spoke.tf
+++ b/azure/tf/spoke.tf
@@ -23,11 +23,11 @@ module "spoke_network" {
   # Networking Parameters
   vnet_cidr                = var.workspace_vnet.cidr
   route_table_id           = var.create_hub ? module.hub[0].route_table_id : var.existing_hub_vnet.route_table_id
-  ipgroup_id               = var.create_hub ? module.hub[0].ipgroup_id : null
+  ipgroup_id               = var.create_hub ? module.hub[0].ipgroup_id : (var.create_spoke_firewall_rules ? azurerm_ip_group.spoke[0].id : null)
   virtual_network_peerings = var.create_hub ? { hub = { remote_virtual_network_id = module.hub[0].vnet_id } } : { hub = { remote_virtual_network_id = var.existing_hub_vnet.vnet_id } }
   workspace_subnets = {
     new_bits        = var.workspace_vnet.new_bits
-    add_to_ip_group = var.create_hub
+    add_to_ip_group = var.create_hub || var.create_spoke_firewall_rules
   }
 }
 
@@ -53,7 +53,7 @@ module "spoke_workspace" {
   # Account parameters
   ncc_id                   = var.create_hub ? module.hub[0].ncc_id : var.existing_ncc_id
   ncc_name                 = var.create_hub ? module.hub[0].ncc_name : var.existing_ncc_name
-  network_policy_id        = var.create_hub ? module.hub[0].network_policy_id : var.existing_network_policy_id
+  network_policy_id        = var.create_hub ? module.hub[0].network_policy_id : (var.create_spoke_network_policy ? databricks_account_network_policy.spoke[0].network_policy_id : var.existing_network_policy_id)
   metastore_id             = var.create_hub ? module.hub[0].metastore_id : var.databricks_metastore_id
   provisioner_principal_id = data.azurerm_client_config.current.object_id
   databricks_account_id    = var.databricks_account_id
@@ -104,5 +104,157 @@ module "spoke_catalog" {
 
   providers = {
     databricks.workspace = databricks.spoke
+  }
+}
+# ---------------
+# Firewall rules
+# ---------------
+# Creates firewall rules for spoke workspaces when using a BYO hub with an existing firewall.
+# This is only used when create_hub = false and create_spoke_firewall_rules = true.
+
+resource "azurerm_ip_group" "spoke" {
+  count = var.create_spoke_firewall_rules ? 1 : 0
+
+  name                = "${var.resource_suffix}-adb-subnets"
+  resource_group_name = local.resource_group_name
+  location            = var.location
+  tags                = var.tags
+
+  lifecycle {
+    ignore_changes = [cidrs]
+  }
+}
+
+locals {
+  # Service tags scoped to the deployment region (same pattern as modules/hub/locals.tf)
+  spoke_fw_service_tags = {
+    "sql"      = "Sql.${title(var.location)}",
+    "storage"  = "Storage.${title(var.location)}",
+    "eventhub" = "EventHub.${title(var.location)}"
+  }
+
+  # Application rules (same pattern as modules/hub/firewall.tf)
+  spoke_fw_application_rules = var.create_spoke_firewall_rules ? [
+    for rule in [
+      {
+        name              = "IPinfo"
+        source_ip_groups  = [azurerm_ip_group.spoke[0].id]
+        destination_fqdns = ["*.ipinfo.io", "ipinfo.io"]
+        protocols = toset([
+          { port = "443", type = "Https" },
+          { port = "8080", type = "Http" },
+          { port = "80", type = "Http" }
+        ])
+      },
+      {
+        name              = "ganglia"
+        source_ip_groups  = [azurerm_ip_group.spoke[0].id]
+        destination_fqdns = ["cdnjs.cloudflare.com"]
+        protocols = toset([
+          { port = "443", type = "Https" }
+        ])
+      },
+      length(var.allowed_fqdns) > 0 ? {
+        name              = "public-repos"
+        source_ip_groups  = [azurerm_ip_group.spoke[0].id]
+        destination_fqdns = var.allowed_fqdns
+        protocols = toset([
+          { port = "443", type = "Https" }
+        ])
+      } : null
+    ] : rule if rule != null
+  ] : []
+}
+
+resource "azurerm_firewall_policy_rule_collection_group" "spoke" {
+  count = var.create_spoke_firewall_rules ? 1 : 0
+
+  name               = "${var.resource_suffix}-databricks-spoke"
+  firewall_policy_id = var.existing_firewall_policy_id
+  priority           = 300
+
+  network_rule_collection {
+    name     = "${var.resource_suffix}-databricks-network-rc"
+    priority = 100
+    action   = "Allow"
+
+    rule {
+      name                  = "adb-storage"
+      protocols             = ["TCP", "UDP"]
+      source_ip_groups      = [azurerm_ip_group.spoke[0].id]
+      destination_addresses = [lookup(local.spoke_fw_service_tags, "storage", "Storage")]
+      destination_ports     = ["443"]
+    }
+
+    rule {
+      name                  = "adb-sql"
+      protocols             = ["TCP"]
+      source_ip_groups      = [azurerm_ip_group.spoke[0].id]
+      destination_addresses = [lookup(local.spoke_fw_service_tags, "sql", "Sql")]
+      destination_ports     = ["3306"]
+    }
+
+    rule {
+      name                  = "adb-eventhub"
+      protocols             = ["TCP"]
+      source_ip_groups      = [azurerm_ip_group.spoke[0].id]
+      destination_addresses = [lookup(local.spoke_fw_service_tags, "eventhub", "EventHub")]
+      destination_ports     = ["9093"]
+    }
+  }
+
+  application_rule_collection {
+    name     = "${var.resource_suffix}-databricks-app-rc"
+    priority = 101
+    action   = "Allow"
+
+    dynamic "rule" {
+      for_each = local.spoke_fw_application_rules
+      content {
+        name              = rule.value.name
+        source_ip_groups  = rule.value.source_ip_groups
+        destination_fqdns = rule.value.destination_fqdns
+        dynamic "protocols" {
+          for_each = rule.value.protocols
+          content {
+            port = protocols.value.port
+            type = protocols.value.type
+          }
+        }
+      }
+    }
+  }
+}
+
+# ---------------
+# Network Policy
+# ---------------
+# Creates a network policy for spoke serverless compute when using a BYO hub.
+# This is only used when create_hub = false and create_spoke_network_policy = true.
+
+locals {
+  spoke_np_allowed_domains = [for dest in var.allowed_fqdns : dest if !startswith(dest, "*.")]
+  spoke_np_allowed_destinations = [
+    for dest in local.spoke_np_allowed_domains :
+    {
+      destination               = dest
+      internet_destination_type = "DNS_NAME"
+    }
+  ]
+}
+
+resource "databricks_account_network_policy" "spoke" {
+  count = var.create_spoke_network_policy ? 1 : 0
+
+  network_policy_id = "np-${var.resource_suffix}-restrictive"
+  account_id        = var.databricks_account_id
+  egress = {
+    network_access = {
+      restriction_mode              = "RESTRICTED_ACCESS"
+      allowed_internet_destinations = local.spoke_np_allowed_destinations
+      policy_enforcement = {
+        enforcement_mode = "ENFORCED"
+      }
+    }
   }
 }

--- a/azure/tf/spoke.tf
+++ b/azure/tf/spoke.tf
@@ -25,6 +25,7 @@ module "spoke_network" {
   route_table_id           = var.create_hub ? module.hub[0].route_table_id : var.existing_hub_vnet.route_table_id
   ipgroup_id               = var.create_hub ? module.hub[0].ipgroup_id : (var.create_spoke_firewall_rules ? azurerm_ip_group.spoke[0].id : null)
   virtual_network_peerings = var.create_hub ? { hub = { remote_virtual_network_id = module.hub[0].vnet_id } } : { hub = { remote_virtual_network_id = var.existing_hub_vnet.vnet_id } }
+  encryption_enabled       = var.workspace_vnet.encryption_enabled || try(var.workspace_security_compliance.compliance_security_profile_enabled, false) == true
   workspace_subnets = {
     new_bits        = var.workspace_vnet.new_bits
     add_to_ip_group = var.create_hub || var.create_spoke_firewall_rules

--- a/azure/tf/spoke.tf
+++ b/azure/tf/spoke.tf
@@ -60,32 +60,6 @@ module "spoke_workspace" {
   databricks_account_id    = var.databricks_account_id
 }
 
-#TODO: The below resources are temporary until the unified provider releases. At that time, they will be merged in to
-# the workspace module.
-resource "databricks_disable_legacy_dbfs_setting" "spoke" {
-  disable_legacy_dbfs {
-    value = true
-  }
-
-  provider_config {
-    workspace_id = module.spoke_workspace.workspace_id
-  }
-
-  depends_on = [module.spoke_workspace]
-}
-
-resource "databricks_disable_legacy_access_setting" "spoke" {
-  disable_legacy_access {
-    value = true
-  }
-
-  provider_config {
-    workspace_id = module.spoke_workspace.workspace_id
-  }
-
-  depends_on = [module.spoke_workspace]
-}
-
 
 module "spoke_catalog" {
   source = "./modules/catalog"

--- a/azure/tf/spoke.tf
+++ b/azure/tf/spoke.tf
@@ -66,8 +66,11 @@ resource "databricks_disable_legacy_dbfs_setting" "spoke" {
     value = true
   }
 
+  provider_config {
+    workspace_id = module.spoke_workspace.workspace_id
+  }
+
   depends_on = [module.spoke_workspace]
-  provider   = databricks.spoke
 }
 
 resource "databricks_disable_legacy_access_setting" "spoke" {
@@ -75,8 +78,11 @@ resource "databricks_disable_legacy_access_setting" "spoke" {
     value = true
   }
 
+  provider_config {
+    workspace_id = module.spoke_workspace.workspace_id
+  }
+
   depends_on = [module.spoke_workspace]
-  provider   = databricks.spoke
 }
 
 
@@ -99,12 +105,9 @@ module "spoke_catalog" {
   metastore_id          = var.create_hub ? module.hub[0].metastore_id : var.databricks_metastore_id
   ncc_id                = module.spoke_workspace.ncc_id
   ncc_name              = module.spoke_workspace.ncc_name
+  workspace_id          = module.spoke_workspace.workspace_id
 
   force_destroy = var.catalog_force_destroy
-
-  providers = {
-    databricks.workspace = databricks.spoke
-  }
 }
 # ---------------
 # Firewall rules

--- a/azure/tf/template.example.tfvars
+++ b/azure/tf/template.example.tfvars
@@ -8,6 +8,7 @@ tags = {
 }
 workspace_vnet = {
   cidr = "10.0.4.0/22"
+  # encryption_enabled = true  # Auto-enabled when workspace_security_compliance.compliance_security_profile_enabled = true
 }
 
 # Network mode: create_workspace_vnet defaults to true for SRA-managed network

--- a/azure/tf/template_byo_hub.example.tfvars
+++ b/azure/tf/template_byo_hub.example.tfvars
@@ -12,21 +12,8 @@ tags = {
   Owner = "user@example.com"
 }
 
-# BYO workspace network configuration
-existing_workspace_vnet = {
-  network_configuration = {
-    virtual_network_id                                   = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-example/providers/Microsoft.Network/virtualNetworks/vnet-example"
-    private_subnet_id                                    = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-example/providers/Microsoft.Network/virtualNetworks/vnet-example/subnets/container"
-    public_subnet_id                                     = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-example/providers/Microsoft.Network/virtualNetworks/vnet-example/subnets/host"
-    private_subnet_network_security_group_association_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-example/providers/Microsoft.Network/virtualNetworks/vnet-example/subnets/container"
-    public_subnet_network_security_group_association_id  = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-example/providers/Microsoft.Network/virtualNetworks/vnet-example/subnets/host"
-    private_endpoint_subnet_id                           = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-example/providers/Microsoft.Network/virtualNetworks/vnet-example/subnets/private-endpoints"
-  }
-  dns_zone_ids = {
-    backend = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-example/providers/Microsoft.Network/privateDnsZones/privatelink.azuredatabricks.net"
-    dfs     = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-example/providers/Microsoft.Network/privateDnsZones/privatelink.dfs.core.windows.net"
-    blob    = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-example/providers/Microsoft.Network/privateDnsZones/privatelink.blob.core.windows.net"
-  }
+workspace_vnet = {
+  cidr = "10.1.0.0/24"
 }
 
 # Use existing resource group
@@ -44,6 +31,17 @@ existing_hub_vnet = {
   route_table_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-external-hub/providers/Microsoft.Network/routeTables/rt-external"
   vnet_id        = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-external-hub/providers/Microsoft.Network/virtualNetworks/vnet-external-hub"
 }
+
+# Optional: Create firewall rules on existing hub firewall for spoke classic compute traffic
+# Requires an existing firewall policy ID from your hub. An IP group will be created automatically.
+# create_spoke_firewall_rules = true
+# existing_firewall_policy_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-external-hub/providers/Microsoft.Network/firewallPolicies/fp-external"
+
+# Optional: Create a Databricks network policy for spoke serverless compute
+# existing_ncc_id must still be provided (NCC is a shared regional resource managed by the hub).
+# create_spoke_network_policy = true
+# existing_ncc_id   = "ncc-00000000-0000-0000-0000-000000000000"
+# existing_ncc_name = "ncc-westus2-myhub"
 
 # Network egress configuration
 allowed_fqdns    = []

--- a/azure/tf/template_byo_hub.example.tfvars
+++ b/azure/tf/template_byo_hub.example.tfvars
@@ -40,7 +40,7 @@ existing_hub_vnet = {
 # Optional: Create a Databricks network policy for spoke serverless compute
 # existing_ncc_id must still be provided (NCC is a shared regional resource managed by the hub).
 # create_spoke_network_policy = true
-# existing_ncc_id   = "ncc-00000000-0000-0000-0000-000000000000"
+# existing_ncc_id   = "00000000-0000-0000-0000-000000000000"
 # existing_ncc_name = "ncc-westus2-myhub"
 
 # Network egress configuration

--- a/azure/tf/template_byo_hub.example.tfvars
+++ b/azure/tf/template_byo_hub.example.tfvars
@@ -40,7 +40,7 @@ existing_hub_vnet = {
 # Optional: Create a Databricks network policy for spoke serverless compute
 # existing_ncc_id must still be provided (NCC is a shared regional resource managed by the hub).
 # create_spoke_network_policy = true
-# existing_ncc_id   = "00000000-0000-0000-0000-000000000000"
+# existing_ncc_id   = "ncc-00000000-0000-0000-0000-000000000000"
 # existing_ncc_name = "ncc-westus2-myhub"
 
 # Network egress configuration

--- a/azure/tf/template_byo_hub.example.tfvars
+++ b/azure/tf/template_byo_hub.example.tfvars
@@ -14,6 +14,7 @@ tags = {
 
 workspace_vnet = {
   cidr = "10.1.0.0/24"
+  # encryption_enabled = true  # Auto-enabled when workspace_security_compliance.compliance_security_profile_enabled = true
 }
 
 # Use existing resource group

--- a/azure/tf/tests/integration.tftest.hcl
+++ b/azure/tf/tests/integration.tftest.hcl
@@ -3,18 +3,20 @@ test {
 }
 
 variables {
-  databricks_host = run.test_initializer.outputs.spoke_workspace_info["workspace_url"]
-  sra_tag         = "SRA Test Suite"
-  catalog_name    = run.test_initializer.outputs.spoke_workspace_catalog
-  open_test_job   = false
+  databricks_host   = run.test_initializer.outputs.spoke_workspace_info["workspace_url"]
+  sra_tag           = "SRA Test Suite"
+  catalog_name      = run.test_initializer.outputs.spoke_workspace_catalog
+  open_test_job     = false
+  auth_profile_name = "tmp-azure-sra-testing"
   environment = {
-    DATABRICKS_HOST          = run.test_initializer.outputs.spoke_workspace_info["workspace_url"]
-    DATABRICKS_BUNDLE_ENGINE = "direct"
-    BUNDLE_VAR_node_type_id  = run.classic_cluster_spoke.node_type_id
-    BUNDLE_VAR_spark_version = run.classic_cluster_spoke.spark_version
-    BUNDLE_VAR_sra_tag       = var.sra_tag
-    BUNDLE_VAR_catalog_name  = var.catalog_name
-    BUNDLE_VAR_cluster_id    = run.classic_cluster_spoke.cluster_id
+    DATABRICKS_HOST           = run.test_initializer.outputs.spoke_workspace_info["workspace_url"]
+    DATABRICKS_BUNDLE_ENGINE  = "direct"
+    DATABRICKS_CONFIG_PROFILE = var.auth_profile_name
+    BUNDLE_VAR_node_type_id   = run.classic_cluster_spoke.node_type_id
+    BUNDLE_VAR_spark_version  = run.classic_cluster_spoke.spark_version
+    BUNDLE_VAR_sra_tag        = var.sra_tag
+    BUNDLE_VAR_catalog_name   = var.catalog_name
+    BUNDLE_VAR_cluster_id     = run.classic_cluster_spoke.cluster_id
   }
 }
 
@@ -24,6 +26,19 @@ run "test_initializer" {
   command   = apply
   module {
     source = "../../common/tests/test_initializer"
+  }
+}
+
+# Create an ephemeral Databricks CLI auth profile for the bundle commands to use
+run "auth_profile" {
+  state_key = "auth_profile"
+  command   = apply
+  module {
+    source = "../../common/tests/auth_profile"
+  }
+  variables {
+    auth_profile_name = var.auth_profile_name
+    host              = "https://${run.test_initializer.outputs.spoke_workspace_info["workspace_url"]}"
   }
 }
 

--- a/azure/tf/variables.tf
+++ b/azure/tf/variables.tf
@@ -175,12 +175,17 @@ variable "existing_ncc_name" {
 
 variable "existing_network_policy_id" {
   type        = string
-  description = "(Optional) ID of the network policy to use, required if create_hub is false"
+  description = "(Optional) ID of the network policy to use. Required if create_hub is false and create_spoke_network_policy is false."
   default     = null
 
   validation {
-    condition     = var.create_hub ? true : var.existing_network_policy_id != null
-    error_message = "If create_hub is false, then you must provide existing_network_policy_id"
+    condition     = var.create_hub ? true : (var.create_spoke_network_policy || var.existing_network_policy_id != null)
+    error_message = "If create_hub is false, you must either provide existing_network_policy_id or set create_spoke_network_policy to true."
+  }
+
+  validation {
+    condition     = var.create_spoke_network_policy ? var.existing_network_policy_id == null : true
+    error_message = "existing_network_policy_id must not be provided when create_spoke_network_policy is true. The network policy will be managed by SRA."
   }
 }
 
@@ -280,4 +285,45 @@ variable "catalog_force_destroy" {
   type        = bool
   default     = false
   description = "Used to allow Terraform to force destroy the catalog. This is only used for testing SRA."
+}
+
+# ------------------------------------------------------------------
+# Spoke Firewall Rules (BYO Hub with firewall management)
+# These variables are used when create_hub = false but you still want
+# SRA to manage firewall rules for spoke workspaces on an existing firewall.
+variable "create_spoke_firewall_rules" {
+  type        = bool
+  description = "(Optional) Whether to create firewall rules for spoke workspaces when using a BYO hub. Only valid when create_hub is false."
+  default     = false
+
+  validation {
+    condition     = var.create_spoke_firewall_rules ? !var.create_hub : true
+    error_message = "create_spoke_firewall_rules can only be true when create_hub is false. When create_hub is true, firewall rules are managed by the hub module."
+  }
+}
+
+variable "existing_firewall_policy_id" {
+  type        = string
+  description = "(Optional) The ID of the existing Azure Firewall Policy to attach spoke rules to. Required when create_spoke_firewall_rules is true."
+  default     = null
+
+  validation {
+    condition     = var.create_spoke_firewall_rules ? var.existing_firewall_policy_id != null : true
+    error_message = "existing_firewall_policy_id is required when create_spoke_firewall_rules is true."
+  }
+}
+
+# ------------------------------------------------------------------
+# Spoke Network Policy (BYO Hub with serverless management)
+# These variables are used when create_hub = false but you still want
+# SRA to manage network policies for spoke serverless compute.
+variable "create_spoke_network_policy" {
+  type        = bool
+  description = "(Optional) Whether to create a network policy for spoke serverless compute when using a BYO hub. Only valid when create_hub is false."
+  default     = false
+
+  validation {
+    condition     = var.create_spoke_network_policy ? !var.create_hub : true
+    error_message = "create_spoke_network_policy can only be true when create_hub is false. When create_hub is true, network policies are managed by the hub module."
+  }
 }

--- a/azure/tf/variables.tf
+++ b/azure/tf/variables.tf
@@ -62,7 +62,9 @@ variable "hub_resource_suffix" {
 # The below variables control what URLs workspaces can access on the internet. By default, no workspace can access the
 # internet at all. Note that this means that SAT will not work by default unless the required URLs are added (see below)
 #
-# Common package registries: ["python.org", "*.python.org", "pypi.org", "*.pypi.org", "pythonhosted.org", "*.pythonhosted.org", "cran.r-project.org", "*.cran.r-project.org", "r-project.org",]
+# Common package registries: ["python.org", "*.python.org", "pypi.org", "*.pypi.org", "pythonhosted.org", "*.pythonhosted.org", "cran.r-project.org", "*.cran.r-project.org", "r-project.org", ]
+# Scala/Java (Maven Central): ["repo1.maven.org", "*.maven.org", "repo.maven.apache.org", "*.maven.apache.org"]
+#   (add "repos.spark-packages.org" if installing Spark Packages, which Databricks also searches by default)
 # SAT Required URLs (classic): ["management.azure.com", "login.microsoftonline.com", "python.org", "*.python.org", "pypi.org", "*.pypi.org", "pythonhosted.org", "*.pythonhosted.org"]
 # SAT Required URLs (serverless): ["management.azure.com", "login.microsoftonline.com", "python.org", "pypi.org", "pythonhosted.org"]
 # Note: This also applies to classic compute in the WEBAUTH workspace

--- a/azure/tf/variables.tf
+++ b/azure/tf/variables.tf
@@ -52,6 +52,10 @@ variable "hub_resource_suffix" {
     condition     = var.create_hub ? length(var.hub_resource_suffix) > 0 : true
     error_message = "hub_resource_suffix is required if create_hub is true"
   }
+  validation {
+    condition     = !strcontains(var.hub_resource_suffix, "-")
+    error_message = "hub_resource_suffix cannot contain dashes (-)."
+  }
 }
 
 # ------------------------------------------------------------------

--- a/azure/tf/variables.tf
+++ b/azure/tf/variables.tf
@@ -282,6 +282,12 @@ variable "sat_force_destroy" {
   description = "Used to allow Terraform to force destroy the SAT catalog. This is only used for testing SRA."
 }
 
+variable "metastore_force_destroy" {
+  type        = bool
+  default     = false
+  description = "Used to allow Terraform to force destroy the metastore. This is only used for testing SRA."
+}
+
 variable "catalog_force_destroy" {
   type        = bool
   default     = false

--- a/azure/tf/variables.tf
+++ b/azure/tf/variables.tf
@@ -110,10 +110,11 @@ variable "create_workspace_vnet" {
 
 variable "workspace_vnet" {
   type = object({
-    cidr     = string
-    new_bits = optional(number, null)
+    cidr               = string
+    new_bits           = optional(number, null)
+    encryption_enabled = optional(bool, false)
   })
-  description = "(Optional) Spoke network configuration - required when create_workspace_vnet is true."
+  description = "(Optional) Spoke network configuration - required when create_workspace_vnet is true. encryption_enabled toggles Azure VNET encryption (AllowUnencrypted enforcement) on the spoke VNET; it is force-enabled when workspace_security_compliance.compliance_security_profile_enabled is true."
   default     = null
 
   validation {

--- a/azure/tf/versions.tf
+++ b/azure/tf/versions.tf
@@ -5,8 +5,9 @@ terraform {
       version = "~>4.9"
     }
     databricks = {
-      source  = "databricks/databricks"
-      version = "~>1.116"
+      source = "databricks/databricks"
+      # Version 1.114 released a regression that has yet to be fixed. This pin will be updated when that is fixed.
+      version = "<1.114.0"
     }
     azuread = {
       source  = "hashicorp/azuread"

--- a/azure/tf/versions.tf
+++ b/azure/tf/versions.tf
@@ -6,7 +6,7 @@ terraform {
     }
     databricks = {
       source  = "databricks/databricks"
-      version = "~>1.81"
+      version = "~>1.116"
     }
     azuread = {
       source  = "hashicorp/azuread"

--- a/docs/sra/docs/usage/Azure/configuration.mdx
+++ b/docs/sra/docs/usage/Azure/configuration.mdx
@@ -364,6 +364,60 @@ cmk_enabled = false
 
 ---
 
+## BYO Hub: Optional SRA-managed Infrastructure
+
+When `create_hub = false`, SRA can optionally manage firewall rules and network policies on your existing hub infrastructure rather than requiring you to provide them externally.
+
+### create_spoke_firewall_rules
+
+**Type:** `bool`
+**Default:** `false`
+**Only valid when:** `create_hub = false`
+
+When `true`, SRA creates an Azure Firewall rule collection group on your existing hub firewall for spoke classic compute egress. An IP group for the spoke subnets is also created automatically.
+
+**Required with:** `existing_firewall_policy_id`
+
+```hcl
+create_spoke_firewall_rules = true
+existing_firewall_policy_id = "/subscriptions/.../firewallPolicies/fp-hub"
+```
+
+Allowed egress destinations are controlled by `allowed_fqdns`, mirroring the classic compute firewall rules that Mode 1 creates in the hub.
+
+### existing_firewall_policy_id
+
+**Type:** `string`
+**Default:** `null`
+**Required when:** `create_spoke_firewall_rules = true`
+
+The Azure Resource ID of the existing hub firewall policy to attach spoke rules to.
+
+### create_spoke_network_policy
+
+**Type:** `bool`
+**Default:** `false`
+**Only valid when:** `create_hub = false`
+
+When `true`, SRA creates a `databricks_account_network_policy` for spoke serverless compute. This makes `existing_network_policy_id` unnecessary (and forbidden). The NCC (`existing_ncc_id`) must still be provided as it is a shared regional resource.
+
+```hcl
+create_spoke_network_policy = true
+existing_ncc_id             = "your-ncc-id"
+```
+
+Allowed egress destinations are sourced from `allowed_fqdns`
+
+<Admonition type="warning" title="Validation Rules">
+
+- `create_spoke_firewall_rules = true` requires `existing_firewall_policy_id`
+- `create_spoke_network_policy = true` requires that `existing_network_policy_id` is **not** set
+- Both flags can only be `true` when `create_hub = false`
+
+</Admonition>
+
+---
+
 ## Security Analysis Tool (SAT)
 
 Configure the Security Analysis Tool for continuous security monitoring.
@@ -606,7 +660,8 @@ Understanding variable dependencies helps avoid configuration errors.
 |---------------|---------------------------|-----|
 | `create_hub = false` | `databricks_metastore_id` | Spoke needs metastore reference |
 | `create_hub = false` | `existing_ncc_id` | Spoke needs NCC for serverless |
-| `create_hub = false` | `existing_network_policy_id` | Spoke needs network policy |
+| `create_hub = false` | `existing_network_policy_id` OR `create_spoke_network_policy = true` | Spoke needs network policy for serverless |
+| `create_spoke_firewall_rules = true` | `existing_firewall_policy_id` | SRA needs the hub firewall policy to attach rules to |
 | `create_hub = false` | `existing_hub_vnet` | Spoke needs hub VNET for peering |
 | `create_hub = false` AND `cmk_enabled = true` | `existing_cmk_ids` | Spoke needs CMK keys for encryption |
 | `create_workspace_vnet = true` | `workspace_vnet` | SRA needs CIDR for spoke network |
@@ -624,6 +679,9 @@ Some variables cannot be used together:
 | `workspace_vnet` AND `existing_workspace_vnet` | Choose one: SRA-managed or existing |
 | `create_hub = true` AND `existing_cmk_ids` | SRA creates CMK when creating hub |
 | `hub_vnet_cidr` when `create_hub = false` | Not creating hub, don't need hub CIDR |
+| `create_spoke_network_policy = true` AND `existing_network_policy_id` | Choose one: SRA-created or existing network policy |
+| `create_spoke_firewall_rules = true` when `create_hub = true` | Firewall rules managed by hub module when hub is created |
+| `create_spoke_network_policy = true` when `create_hub = true` | Network policy managed by hub module when hub is created |
 
 ---
 

--- a/docs/sra/docs/usage/Azure/deploymentmodes.mdx
+++ b/docs/sra/docs/usage/Azure/deploymentmodes.mdx
@@ -53,13 +53,15 @@ flowchart TD
 ### [Mode 2: Bring-your-own Hub](./mode2-byo-hub.mdx)
 - **Best for:** Teams with existing hub infrastructure
 - **SRA creates:** Spoke resources only
-- **You provide:** Hub VNET, Key Vault, metastore, NCC, network policy
+- **You provide:** Hub VNET, Key Vault, metastore, NCC
+- **Optional:** SRA can manage firewall rules (`create_spoke_firewall_rules`) and network policy (`create_spoke_network_policy`) on your existing hub
 - **Template:** `template_byo_hub.example.tfvars`
 
 ### [Mode 3: Bring-your-own Hub + Spoke](./mode3-byo-hub-spoke.mdx)
 - **Best for:** Organizations with fully existing infrastructure
 - **SRA creates:** Workspace and related resources only
-- **You provide:** Hub VNET, Key Vault, metastore, NCC, network policy, spoke VNET
+- **You provide:** Hub VNET, Key Vault, metastore, NCC, spoke VNET
+- **Optional:** SRA can manage firewall rules (`create_spoke_firewall_rules`) and network policy (`create_spoke_network_policy`) on your existing hub
 - **Template:** `template_byo_spoke_network.example.tfvars`
 
 ## Next Steps

--- a/docs/sra/docs/usage/Azure/mode2-byo-hub.mdx
+++ b/docs/sra/docs/usage/Azure/mode2-byo-hub.mdx
@@ -6,7 +6,7 @@ import Admonition from '@theme/Admonition';
 # Mode 2: Bring-your-own Hub
 
 ## Description
-You provide an existing hub infrastructure (VNET, Key Vault, metastore, NCC, network policy). SRA creates only the spoke workspace with a managed spoke network.
+You provide an existing hub infrastructure (VNET, Key Vault, metastore, NCC). SRA creates the spoke workspace with a managed spoke network. Optionally, SRA can also manage firewall rules and network policies for each spoke.
 
 ## What Gets Created
 
@@ -61,7 +61,7 @@ You provide an existing hub infrastructure (VNET, Key Vault, metastore, NCC, net
     </tr>
     <tr className='bg-gray-50'>
       <td className='p-3'>Network Policy</td>
-      <td className='p-3 text-center'>✗ (You provide)</td>
+      <td className='p-3 text-center'>✗ / ✓ (Optional — see below)</td>
     </tr>
     <tr className='bg-gray-50'>
       <td className='p-3'>Metastore</td>
@@ -102,8 +102,10 @@ existing_hub_vnet = {
   vnet_id        = "/subscriptions/.../providers/Microsoft.Network/virtualNetworks/vnet-hub"
 }
 
-# REQUIRED: Existing NCC and network policy
-existing_ncc_id            = "your-ncc-id"
+# REQUIRED: Existing NCC
+existing_ncc_id = "your-ncc-id"
+
+# REQUIRED: Provide an existing network policy OR set create_spoke_network_policy = true to have SRA create one
 existing_network_policy_id = "your-network-policy-id"
 
 # REQUIRED if cmk_enabled = true (default)
@@ -125,7 +127,7 @@ tags = {
 - `resource_suffix`
 - `databricks_metastore_id`
 - `existing_ncc_id`
-- `existing_network_policy_id`
+- `existing_network_policy_id` OR `create_spoke_network_policy = true`
 - `existing_hub_vnet`
 - `existing_cmk_ids` (if `cmk_enabled = true`)
 
@@ -150,15 +152,43 @@ The Security Analysis Tool (SAT) can only be deployed when `create_hub = true`. 
 
 </Admonition>
 
+## Optional: SRA-managed Firewall Rules and Network Policy
+
+When using a BYO hub, SRA can optionally manage firewall rules and network policies on your existing hub infrastructure.
+
+<Admonition type="info" title="Firewall Rules (Classic Compute)">
+
+Set `create_spoke_firewall_rules = true` to have SRA create firewall rules for spoke classic compute on your existing hub firewall. Requires `existing_firewall_policy_id`.
+
+```hcl
+create_spoke_firewall_rules = true
+existing_firewall_policy_id = "/subscriptions/.../firewallPolicies/fp-hub"
+```
+
+</Admonition>
+
+<Admonition type="info" title="Network Policy (Serverless)">
+
+Set `create_spoke_network_policy = true` to have SRA create a Databricks network policy for spoke serverless compute. When set, `existing_network_policy_id` must not be provided. The NCC (`existing_ncc_id`) must still be supplied as it is a shared regional resource.
+
+```hcl
+create_spoke_network_policy = true
+existing_ncc_id             = "your-ncc-id"
+```
+
+</Admonition>
+
 ## Validation Rules
 
 When `create_hub = false`:
 - Must provide `databricks_metastore_id`
 - Must provide `existing_ncc_id`
-- Must provide `existing_network_policy_id`
+- Must provide `existing_network_policy_id` OR set `create_spoke_network_policy = true`
+- Must NOT provide `existing_network_policy_id` when `create_spoke_network_policy = true`
 - Must provide `existing_hub_vnet`
 - Must provide `existing_cmk_ids` if `cmk_enabled = true`
 - Must NOT provide `existing_cmk_ids` if `cmk_enabled = false`
+- `create_spoke_firewall_rules` requires `existing_firewall_policy_id`
 
 ## Next Steps
 

--- a/docs/sra/docs/usage/Azure/mode3-byo-hub-spoke.mdx
+++ b/docs/sra/docs/usage/Azure/mode3-byo-hub-spoke.mdx
@@ -61,7 +61,7 @@ You provide both existing hub and spoke infrastructure. SRA is only responsible 
     </tr>
     <tr className='bg-gray-50'>
       <td className='p-3'>Network Policy</td>
-      <td className='p-3 text-center'>✗ (You provide)</td>
+      <td className='p-3 text-center'>✗ / ✓ (Optional — see Mode 2)</td>
     </tr>
     <tr className='bg-gray-50'>
       <td className='p-3'>Metastore</td>
@@ -105,8 +105,10 @@ existing_hub_vnet = {
   vnet_id        = "/subscriptions/.../providers/Microsoft.Network/virtualNetworks/vnet-hub"
 }
 
-# REQUIRED: Existing NCC and network policy
-existing_ncc_id            = "your-ncc-id"
+# REQUIRED: Existing NCC
+existing_ncc_id = "your-ncc-id"
+
+# REQUIRED: Provide an existing network policy OR set create_spoke_network_policy = true to have SRA create one
 existing_network_policy_id = "your-network-policy-id"
 
 # REQUIRED if cmk_enabled = true (default)
@@ -149,7 +151,7 @@ tags = {
 - `resource_suffix`
 - `databricks_metastore_id`
 - `existing_ncc_id`
-- `existing_network_policy_id`
+- `existing_network_policy_id` OR `create_spoke_network_policy = true`
 - `existing_hub_vnet`
 - `existing_cmk_ids` (if `cmk_enabled = true`)
 - `existing_workspace_vnet`
@@ -162,7 +164,8 @@ Use `template_byo_spoke_network.example.tfvars` as your starting point.
 When `create_hub = false`:
 - Must provide `databricks_metastore_id`
 - Must provide `existing_ncc_id`
-- Must provide `existing_network_policy_id`
+- Must provide `existing_network_policy_id` OR set `create_spoke_network_policy = true`
+- Must NOT provide `existing_network_policy_id` when `create_spoke_network_policy = true`
 - Must provide `existing_hub_vnet`
 - Must provide `existing_cmk_ids` if `cmk_enabled = true`
 - Must NOT provide `existing_cmk_ids` if `cmk_enabled = false`


### PR DESCRIPTION
## Features

* **azure:** stop creating subnets for hub workspace ([03923a3](https://github.com/databricks/terraform-databricks-sra/commit/03923a31d91e22f82a261f775f8fa5ffcb85a460))
* **azure:** move disable-legacy-settings into the workspace module ([23a0459](https://github.com/databricks/terraform-databricks-sra/commit/23a0459738ee590f1c887961f55ebffe853927fe))
* **azure:** update workspace module to use AzureRM CSP settings ([f89c289](https://github.com/databricks/terraform-databricks-sra/commit/f89c28949e44961e0067701b886c531f2f52e40d))
* **azure:** switch hub workspace to be a serverless-only workspace ([2182580](https://github.com/databricks/terraform-databricks-sra/commit/2182580bd5011e55830bdfa007a2e0c05f9ae2c2))
* **azure:** add support for VNET encryption ([5f2fded](https://github.com/databricks/terraform-databricks-sra/commit/5f2fdedc6da5433e4fefb8a559aca59e9416ca6f))
* **azure:** switch to unified provider ([c9993b7](https://github.com/databricks/terraform-databricks-sra/commit/c9993b7284224b72d04989653b3e3ebf658a33c3))
* **azure:** support spoke deployment creating firewall rules on existing hub infrastructure ([2b9fd9f](https://github.com/databricks/terraform-databricks-sra/commit/2b9fd9f9ab33b7621d8a849465857fc204c5c7da))

## Bug Fixes

* **azure:** ignore effective file event queue changes on storage accounts to support UC-enabled queues ([11540ca](https://github.com/databricks/terraform-databricks-sra/commit/11540ca00f51c3d0bc3bc679f1dd2384da7c02ff))
* **azure:** remove unneeded legacy setting resources ([62685b5](https://github.com/databricks/terraform-databricks-sra/commit/62685b5f0e67590b637d68b74a4e9eea03752c9a))
* **azure:** remove unused uc-owners group ([d645913](https://github.com/databricks/terraform-databricks-sra/commit/d6459137e9b14fbae1d68620fb83e7506e8f700f))
* **azure:** disallow use of dashes in `hub_resource_suffix` ([bb874c6](https://github.com/databricks/terraform-databricks-sra/commit/bb874c63abc46725925a21d92e75e4850b09483b))
* **azure:** handle case when there are no NCCs in a region ([e906aca](https://github.com/databricks/terraform-databricks-sra/commit/e906acac5eeb9a8cf67d5849f799179889e9a3ce))
* **azure:** make `force_destroy` on metastore optional, default `false` ([86ac988](https://github.com/databricks/terraform-databricks-sra/commit/86ac988d9750dd9cca0cdbdf57ac5df57a83a607))
* **azure:** pin databricks provider to `<1.114.0` to avoid unified-provider-related bug ([c5d9c14](https://github.com/databricks/terraform-databricks-sra/commit/c5d9c1400e0bb3586b77d417d7f3a18c61c2466d))
* **azure:** remove `existing_workspace_vnet` variable from byo_hub template ([1fc35f4](https://github.com/databricks/terraform-databricks-sra/commit/1fc35f45cde67241b5e99e87c796493fdd41e73a), [1482e8a](https://github.com/databricks/terraform-databricks-sra/commit/1482e8a44f5c13aa2e7980190dc178ab6e494c56))

## Documentation

* **azure:** add maven URLs to firewall comments ([691baf3](https://github.com/databricks/terraform-databricks-sra/commit/691baf3635405c44cef8cb4194830377f990bded))
* **azure:** fix byo_hub TFVars ncc id example ([53ee0df](https://github.com/databricks/terraform-databricks-sra/commit/53ee0dfb58dc6a150084ecc90efec17515922bc5))
* **azure:** various updates for new firewall feature ([4ebb3d3](https://github.com/databricks/terraform-databricks-sra/commit/4ebb3d339405a22e6f867a263ca0153951910190))

## Tests

* **azure:** add missing tflint files ([034569e](https://github.com/databricks/terraform-databricks-sra/commit/034569e05cd1999f9def9f559f1bb69c51906ff5))

## Continuous Integration

* add `.claude` settings to gitignore ([72a7b7a](https://github.com/databricks/terraform-databricks-sra/commit/72a7b7ae31afd0ab83814eaaa010d719717ab882))

---

### Upgrade notes

* **Unified provider migration** — the configuration now uses the unified Databricks
  provider ([c9993b7](https://github.com/databricks/terraform-databricks-sra/commit/c9993b7284224b72d04989653b3e3ebf658a33c3)), with a temporary
  pin to `<1.114.0` ([c5d9c14](https://github.com/databricks/terraform-databricks-sra/commit/c5d9c1400e0bb3586b77d417d7f3a18c61c2466d)).
* **Serverless-only hub** — the hub workspace is now serverless-only and no longer
  creates its own subnets ([2182580](https://github.com/databricks/terraform-databricks-sra/commit/2182580bd5011e55830bdfa007a2e0c05f9ae2c2),
  [03923a3](https://github.com/databricks/terraform-databricks-sra/commit/03923a31d91e22f82a261f775f8fa5ffcb85a460)). A new `serverless_workspace`
  module is introduced.
* **Removed variable** — `existing_workspace_vnet` was removed from the byo_hub
  template; update any tfvars that referenced it.
* **Metastore `force_destroy`** now defaults to `false`
  ([86ac988](https://github.com/databricks/terraform-databricks-sra/commit/86ac988d9750dd9cca0cdbdf57ac5df57a83a607)).
* **`hub_resource_suffix`** can no longer contain dashes
  ([bb874c6](https://github.com/databricks/terraform-databricks-sra/commit/bb874c63abc46725925a21d92e75e4850b09483b)).
* **These changes are not backward-compatible, you should not apply these changes on top of an existing SRA deployment**
