### PR TITLE
key rotation + SAT domains

### DIFF
--- a/aws/tf/cmk.tf
+++ b/aws/tf/cmk.tf
@@ -6,6 +6,7 @@ locals {
 
 resource "aws_kms_key" "workspace_storage" {
   description = "KMS key for databricks workspace storage"
+  enable_key_rotation = true
   policy = jsonencode({
     Version : "2012-10-17",
     "Id" : "key-policy-workspace-storage",
@@ -78,6 +79,7 @@ resource "aws_kms_alias" "workspace_storage_key_alias" {
 
 resource "aws_kms_key" "managed_services" {
   description = "KMS key for managed services"
+  enable_key_rotation = true
   policy = jsonencode({ Version : "2012-10-17",
     "Id" : "key-policy-managed-services",
     Statement : [

--- a/aws/tf/modules/databricks_account/network_policy/main.tf
+++ b/aws/tf/modules/databricks_account/network_policy/main.tf
@@ -23,6 +23,18 @@ resource "databricks_account_network_policy" "restrictive_network_policy" {
         {
           destination               = "files.pythonhosted.org"
           internet_destination_type = "DNS_NAME"
+        },
+        {
+          destination               = "release-assets.githubusercontent.com"
+          internet_destination_type = "DNS_NAME"
+        },
+        {
+          destination               = "github.com"
+          internet_destination_type = "DNS_NAME"
+        },
+        {
+          destination               = "raw.githubusercontent.com"
+          internet_destination_type = "DNS_NAME"
         }
       ] : []
     }


### PR DESCRIPTION
Enabling auto key rotation for CMK for both workspace storage + managed services
Also adding additional domains to network policy required for SAT Secrets Scanning (if SAT is enabled)