### PR TITLE
[AWS] Set explicit private_access ingress mode on the network policy

### DIFF
--- a/aws/tf/modules/databricks_account/network_policy/main.tf
+++ b/aws/tf/modules/databricks_account/network_policy/main.tf
@@ -44,6 +44,13 @@ resource "databricks_account_network_policy" "restrictive_network_policy" {
   # to the workspace is restricted to the listed IPs/CIDRs; otherwise public access is left unrestricted.
   # NOTE: Verify that all IPs are correct before enabling this feature to prevent a lockout scenario.
   ingress = {
+    # Explicitly allow private access from all VPC endpoints registered in the account, matching the
+    # private access settings posture (private_access_level = "ACCOUNT"). The API now populates
+    # private_access server-side when unset, which the provider reports as an inconsistent result after
+    # apply ("was null, but now ..."); setting it explicitly avoids that error.
+    private_access = {
+      restriction_mode = "ALLOW_ALL_REGISTERED_ENDPOINTS"
+    }
     public_access = {
       restriction_mode = length(var.context_based_ingress_ip_acl) > 0 ? "RESTRICTED_ACCESS" : "FULL_ACCESS"
       allow_rules = length(var.context_based_ingress_ip_acl) > 0 ? [


### PR DESCRIPTION
The network policy API now populates ingress.private_access server-side when unset, and the provider reports it as an inconsistent result after apply. Explicitly set restriction_mode = ALLOW_ALL_REGISTERED_ENDPOINTS, which matches the existing private access settings posture (private_access_level = ACCOUNT).