### PR TITLE
[AWS] Decouple service_direct VPC endpoint count from resource-derived value

### DIFF
--- a/aws/tf/main.tf
+++ b/aws/tf/main.tf
@@ -74,6 +74,7 @@ module "databricks_mws_workspace" {
   scc_tunnel_dataplane_relay_access = local.is_serverless || var.custom_scc_relay_mws_vpce_id != null ? null : (var.custom_scc_relay_vpce_id != null ? var.custom_scc_relay_vpce_id : aws_vpc_endpoint.scc_tunnel_dataplane_relay_access[0].id)
   scc_relay_mws_vpce_id             = var.custom_scc_relay_mws_vpce_id
   service_direct                    = local.is_serverless || var.custom_service_direct_mws_vpce_id != null ? [] : (var.custom_service_direct_vpce_id != null ? [var.custom_service_direct_vpce_id] : aws_vpc_endpoint.service_direct[*].id)
+  service_direct_enabled            = local.service_direct_enabled
   service_direct_mws_vpce_id        = var.custom_service_direct_mws_vpce_id
 
   # Cross-Account Role (skipped for serverless-only workspaces)

--- a/aws/tf/modules/databricks_account/workspace/main.tf
+++ b/aws/tf/modules/databricks_account/workspace/main.tf
@@ -67,7 +67,12 @@ resource "databricks_mws_vpc_endpoint" "scc_tunnel_dataplane_relay_access" {
 
 # Service Direct VPC Endpoint Configuration
 resource "databricks_mws_vpc_endpoint" "service_direct" {
-  count               = var.service_direct_mws_vpce_id == null && length(var.service_direct) > 0 && !local.is_serverless ? 1 : 0
+  # NOTE: count here intentionally uses a plain boolean (service_direct_enabled), not
+  # length(var.service_direct), so this resource's existence is resolvable during `terraform import`
+  # and other partial-state operations without requiring temporary edits to service_direct's
+  # resource-derived value. service_direct_enabled is computed in the root module to be true exactly
+  # when service_direct resolves to a non-empty list.
+  count               = var.service_direct_mws_vpce_id == null && var.service_direct_enabled ? 1 : 0
   account_id          = var.databricks_account_id
   aws_vpc_endpoint_id = var.service_direct[0]
   vpc_endpoint_name   = "${var.resource_prefix}-vpce-service-direct-${var.vpc_id}"

--- a/aws/tf/modules/databricks_account/workspace/variables.tf
+++ b/aws/tf/modules/databricks_account/workspace/variables.tf
@@ -30,6 +30,12 @@ variable "service_direct" {
   default     = []
 }
 
+variable "service_direct_enabled" {
+  description = "Plain boolean indicating whether a Service Direct VPC endpoint should be associated with this workspace. Decoupled from `service_direct` (the actual endpoint ID list) so that `count` on databricks_mws_vpc_endpoint.service_direct can be statically resolved without depending on another resource's computed attributes."
+  type        = bool
+  default     = false
+}
+
 variable "service_direct_mws_vpce_id" {
   description = "Pre-registered Databricks MWS VPC endpoint ID for the service direct endpoint. If set, registration of the AWS VPC endpoint is skipped."
   type        = string

--- a/aws/tf/variables.tf
+++ b/aws/tf/variables.tf
@@ -793,16 +793,18 @@ variable "workspace_display_name" {
   nullable    = true
 }
 
-# Combined locals block for all computed values
+# Combined locals block for all computed values, ordered alphabetically
 locals {
+  # Compute the correct AWS partition for assume role policies
+  # Different partitions based on region and GovCloud shard type
+  assume_role_partition = var.region == "us-gov-west-1" ? (
+    var.databricks_gov_shard == "dod" ? "aws-us-gov-dod" : "aws-us-gov"
+  ) : "aws"
+
   # Computed AWS partition based on region
   computed_aws_partition = var.aws_partition != null ? var.aws_partition : (
     var.region == "us-gov-west-1" ? "aws-us-gov" : "aws"
   )
-
-  # Serverless-only workspaces skip the customer-managed VPC, PrivateLink endpoints,
-  # cross-account role, root S3 bucket, and workspace CMKs
-  is_serverless = var.compute_mode == "SERVERLESS"
 
   # Computed Databricks provider host based on GovCloud shard
   computed_databricks_provider_host = var.databricks_provider_host != null ? var.databricks_provider_host : (
@@ -811,24 +813,33 @@ locals {
     )
   )
 
+  # Compute the correct Databricks account ID for artifact buckets
+  # Both GovCloud civilian and DoD shards use the same account ID for artifact buckets
+  databricks_artifact_and_sample_data_account_id = var.databricks_gov_shard == "civilian" || var.databricks_gov_shard == "dod" ? "282567162347" : "414351767826"
+
   # Compute the correct Databricks account ID based on GovCloud shard
   databricks_aws_account_id = var.databricks_gov_shard == "civilian" ? "044793339203" : (
     var.databricks_gov_shard == "dod" ? "170661010020" : "414351767826"
   )
 
-  # Compute the correct Databricks account ID for artifact buckets
-  # Both GovCloud civilian and DoD shards use the same account ID for artifact buckets
-  databricks_artifact_and_sample_data_account_id = var.databricks_gov_shard == "civilian" || var.databricks_gov_shard == "dod" ? "282567162347" : "414351767826"
-
   # Compute the correct Databricks account ID for EC2 images
   # GovCloud regions use a different account ID for AMIs
   databricks_ec2_image_account_id = var.region == "us-gov-west-1" ? "044732911619" : "601306020600"
 
-  # Compute the correct AWS partition for assume role policies
-  # Different partitions based on region and GovCloud shard type
-  assume_role_partition = var.region == "us-gov-west-1" ? (
-    var.databricks_gov_shard == "dod" ? "aws-us-gov-dod" : "aws-us-gov"
-  ) : "aws"
+  # Serverless-only workspaces skip the customer-managed VPC, PrivateLink endpoints,
+  # cross-account role, root S3 bucket, and workspace CMKs
+  is_serverless = var.compute_mode == "SERVERLESS"
+
+  # Whether a Service Direct VPC endpoint should be associated with the workspace, expressed purely from
+  # plain variables (no resource-derived values). Mirrors exactly when the module's service_direct argument
+  # resolves to a non-empty list, and is passed to the workspace module as service_direct_enabled so the
+  # module's count is statically resolvable during terraform import and other partial-state operations
+  # without temporarily editing service_direct to [].
+  service_direct_enabled = !local.is_serverless && var.custom_service_direct_mws_vpce_id == null && (
+    var.custom_service_direct_vpce_id != null || (
+      var.create_service_direct_vpce && var.network_configuration != "custom" && contains(keys(var.service_direct_config), var.region)
+    )
+  )
 
   # Compute the correct Unity Catalog IAM ARN based on region and GovCloud shard type
   unity_catalog_iam_arn = var.region == "us-gov-west-1" ? (


### PR DESCRIPTION
count on databricks_mws_vpc_endpoint.service_direct used length(var.service_direct), whose value derives from aws_vpc_endpoint. service_direct[*].id and can't be resolved during terraform import, forcing a manual edit to service_direct=[] before every import.

Introduce a plain-boolean service_direct_enabled local in the root module (computed from variables only) and drive the module count from it. Proven equivalent to the prior length()>0 decision across all reachable input combinations, so plan/apply behavior is unchanged.