### PR TITLE
Fix ap-southeast-3 General Access endpoint

### DIFF
--- a/aws/tf/variables.tf
+++ b/aws/tf/variables.tf
@@ -267,7 +267,7 @@ variable "general_access_config" {
       primary_endpoint = "com.amazonaws.vpce.ap-southeast-2.vpce-svc-0b87155ddd6954974"
     }
     "ap-southeast-3" = {
-      primary_endpoint = "com.amazonaws.vpce.ap-southeast-3.vpce-svc-07a698e7e9ccfd04a"
+      primary_endpoint = "com.amazonaws.vpce.ap-southeast-3.vpce-svc-0fec4092997affd53"
     }
     "ca-central-1" = {
       primary_endpoint = "com.amazonaws.vpce.ca-central-1.vpce-svc-0205f197ec0e28d65"


### PR DESCRIPTION
## Summary

Update the ap-southeast-3 (Jakarta) General Access PrivateLink service from `vpce-svc-07a698e7e9ccfd04a` to `vpce-svc-0fec4092997affd53`.

The current Databricks regional IP addresses and domains documentation points to `com.amazonaws.vpce.ap-southeast-3.vpce-svc-0fec4092997affd53` for General Access, while the SRA configuration currently points to the other VPC endpoint service.

Documentation: https://docs.databricks.com/aws/en/resources/ip-domain-region#privatelink

## Validation

- Compared the regional General Access and SCC relay service names against the current documentation.
- Ran `terraform fmt -check aws/tf/variables.tf`.
- Ran `git diff --check`.